### PR TITLE
Add Load Scenario Modal Package

### DIFF
--- a/250923_05_default_template_behavior.md
+++ b/250923_05_default_template_behavior.md
@@ -1,0 +1,6740 @@
+# Save simulation name and redirect URL
+_Exported on 23/09/2025 at 18:48:14 CEST from Cursor (1.5.5)_
+
+---
+
+**User**
+
+Save as name : a note to tell user to name it os.getenv("CD_ENV") (ex. "dev") _ simul_ some name
+an example being : dev_simul_test0001
+
+when user has used "save as feature" , after saving successful url page to redirect to https://bo.scandpe.fr/simul/index.html?ref_ademe={ref_ademe}&simul={name which was set}
+
+---
+
+**Cursor**
+
+I'll locate the "Save as" feature in the editor to add the naming hint and implement the post-save redirect.
+
+I'll scan the editor code for the Save As implementation and references to ref_ademe so I can add the naming hint and implement the redirect after a successful save.
+
+I'll open the editor component to locate the Save As UI and hook the redirect after a successful save.
+
+I'll create two tasks: add the Save As naming hint and implement the redirect on successful save. Then I'll open `apps/simul/src/App.tsx` to modify the Save As modal and the success handler.
+
+I'll open `apps/simul/src/App.tsx` to implement the naming hint and then wire the redirect after save succeeds.
+
+I'll update the Save As prompt to include the naming hint and then implement the redirect to the specified URL after a successful save.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        if (cancelled) return;
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await waitForAccessToken(15000, 250);
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+        if (cancelled) return;
+
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    run();
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh") { run(); }
+      } catch {}
+    });
+    return () => { try { (removeHub as any)?.(); } catch {}; cancelled = true; };
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const cdEnv = ((import.meta as any)?.env?.VITE_CD_ENV as string | undefined) || (import.meta.env.MODE === "development" ? "dev" : "prod");
+                      const suggested = `${cdEnv}_simul_${simulLog || "test0001"}`;
+                      const name = window.prompt(
+                        "Save as name (format: <CD_ENV>_simul_<name>, e.g., dev_simul_test0001):",
+                        suggested
+                      );
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                        if (refAdeme) {
+                          const targetUrl = `https://bo.scandpe.fr/simul/index.html?ref_ademe=${encodeURIComponent(refAdeme)}&simul=${encodeURIComponent(name)}`;
+                          window.location.href = targetUrl;
+                        }
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+- I updated the Save As prompt to suggest a name using your env, e.g., “dev_simul_test0001”, and clearly instruct the format.
+- After a successful Save As, it now redirects to `https://bo.scandpe.fr/simul/index.html?ref_ademe={ref_ademe}&simul={name}`.
+
+Key edit in `apps/simul/src/App.tsx`:
+- Enhanced the prompt with a suggested value based on `VITE_CD_ENV` (fallback to `dev`/`prod`).
+- On success, navigate to the required URL with `ref_ademe` and `simul` query params.
+
+---
+
+**User**
+
+in editor (right drawer) i think there is a mistake, i guess it takes 1st entry in scenario , but instead if should take the value in current json matching template `scenarios.n.input.` ... (ex. donnee_entree.epaisseur_isolation)
+
+---
+
+**Cursor**
+
+I'll inspect the right drawer editor code to find where it reads scenario values and adjust it to read from the current JSON at scenarios[n].input instead of defaulting to the first scenario.
+
+I'll open the editor component to inspect how it derives scenario values and identify where it's selecting the first scenario instead of matching current JSON keys.
+
+I'll update the right drawer editor to derive the scenario input/cost keys from the template's scenarios (when available) instead of defaulting to the first key of the first scenario in the current JSON. Then I'll run a linter check.
+
+I'll add template-based key detection to the editor so it prefers `scenarios[n].input.*` keys from the template when deriving scenario input/cost keys, update all fallback logic accordingly, and ensure the file still lints cleanly.
+
+```typescriptreact
+*** Begin Patch
+*** Update File: /Volumes/privateGg/ai-microfront-ant/packages/dpe-editor/src/ui/DpeDrawerEditor.tsx
+@@
+   function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+@@
+   }
+ 
++  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
++    try {
++      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
++      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
++      for (const sc of scenarios) {
++        const inputObj = sc?.input || sc?.inputs || undefined;
++        if (inputObj && typeof inputObj === "object") {
++          const keys = Object.keys(inputObj);
++          if (keys.length > 0) return keys[0];
++        }
++      }
++    } catch {}
++    return undefined;
++  }
++
+   function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+@@
+   }
++
++  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
++    try {
++      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
++      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
++      for (const sc of scenarios) {
++        const costObj = sc?.cost || undefined;
++        if (costObj && typeof costObj === "object") {
++          const keys = Object.keys(costObj);
++          if (keys.length > 0) return keys[0];
++        }
++      }
++    } catch {}
++    return undefined;
++  }
+@@
+-      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+-      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
++      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
++      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+@@
+-      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+-      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
++      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
++      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+*** End Patch
+```
+
+I’m going to update the drawer editor logic to prefer scenario keys derived from the template when picking `input`/`cost` keys, add helper functions to fetch those keys from `templateRuns`, and update usages throughout. Then I’ll lint the file.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+- I fixed the right drawer logic to prefer the template’s `scenarios[n].input.*` and `scenarios[n].cost.*` keys when deriving scenario mappings, instead of defaulting to the first key from the current JSON’s first scenario.
+- This change ensures values like `donnee_entree.epaisseur_isolation` are taken from the template structure, matching the current JSON by scenario id.
+
+Edits in `packages/dpe-editor/src/ui/DpeDrawerEditor.tsx`:
+- Added `getTemplateScenarioInputKey` and `getTemplateScenarioCostKey`.
+- Updated derivation to use template-based keys first, then fallback to current JSON, then default:
+  - For increments: prefers template input key → current JSON key → `"donnee_entree.epaisseur_isolation"`.
+  - For cost: prefers template cost key → current JSON key → `"donnee_entree.surface_paroi_opaque"`.
+
+Linting passed with no errors.
+
+---
+
+**User**
+
+unfortunately i still get the "donnee_entree.enum_type_isolation_id" key from the current json instead of the key matching run. ... scenarios from template
+
+---
+
+**Cursor**
+
+I'll scan the editor file to find where the configured input/cost keys are chosen during apply and update them to prefer the template keys, then adjust and lint.
+
+I'll update the editor to use template-based keys wherever configured input/cost keys are selected and in the UI's prefilled key fields, then lint the file.
+
+I’m going to update the editor code to prefer template-derived scenario keys everywhere they are chosen, add helper functions to get keys from arbitrary runs arrays, then lint the file.
+
+```typescriptreact
+*** Begin Patch
+*** Update File: /Volumes/privateGg/ai-microfront-ant/packages/dpe-editor/src/ui/DpeDrawerEditor.tsx
+@@
+   function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+@@
+   }
+ 
+   function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+@@
+   }
+ 
+   function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+@@
+   }
+ 
+   function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+@@
+   }
++
++  // Helpers to derive keys directly from a provided runs[] array (e.g., template)
++  function getFirstScenarioInputKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
++    try {
++      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
++      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
++      for (const sc of scenarios) {
++        const inputObj = sc?.input || sc?.inputs || undefined;
++        if (inputObj && typeof inputObj === "object") {
++          const keys = Object.keys(inputObj);
++          if (keys.length > 0) return keys[0];
++        }
++      }
++    } catch {}
++    return undefined;
++  }
++
++  function getFirstScenarioCostKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
++    try {
++      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
++      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
++      for (const sc of scenarios) {
++        const costObj = sc?.cost || undefined;
++        if (costObj && typeof costObj === "object") {
++          const keys = Object.keys(costObj);
++          if (keys.length > 0) return keys[0];
++        }
++      }
++    } catch {}
++    return undefined;
++  }
+@@
+   function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+@@
+-      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+-      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
++      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKeyFromRuns(runsArr, variantId) || "donnee_entree.epaisseur_isolation";
++      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKeyFromRuns(runsArr, variantId) || "donnee_entree.surface_paroi_opaque";
+@@
+-          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+-          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
++          const configuredInputKey = mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
++          const configuredCostKey = mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+@@
+-        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+-        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
++        const configuredInputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
++        const configuredCostKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+*** End Patch
+```
+
+Let me open the editor file to modify the key selection fallback logic to prefer template-derived keys, then I'll lint it.
+
+I'll update the editor to prefer template-derived scenario keys during template-derived computation, apply/save, toggle scenario presence, and UI placeholders. Then I'll run a lint check on the modified file.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKeyFromRuns(runsArr, variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKeyFromRuns(runsArr, variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKeyFromRuns(runsArr, variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKeyFromRuns(runsArr, variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getTemplateScenarioInputKey(colSettings.variant) || getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getTemplateScenarioCostKey(colSettings.variant) || getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+I'll add the missing helper functions to derive keys from an arbitrary runs array and rerun the linter.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKeyFromRuns(runsArr, variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKeyFromRuns(runsArr, variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  // Helpers to derive keys directly from a provided runs[] array (e.g., template)
+  function getFirstScenarioInputKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getTemplateScenarioInputKey(colSettings.variant) || getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getTemplateScenarioCostKey(colSettings.variant) || getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+Fixed: the editor now prioritizes template scenario keys.
+
+- Changed key selection to use template keys first everywhere:
+  - Template-derived computation
+  - Apply/save path
+  - Toggle scenario presence
+  - Column settings placeholders
+
+- Added helpers to derive keys from arbitrary `runs[]`:
+  - `getFirstScenarioInputKeyFromRuns`
+  - `getFirstScenarioCostKeyFromRuns`
+
+Now, when template scenarios specify `scenarios[n].input.donnee_entree.epaisseur_isolation`, the editor uses that instead of keys found in the current JSON like `donnee_entree.enum_type_isolation_id`.
+
+---
+
+**User**
+
+save as : when routing to saved name, /index.html?ref_ademe=2501E2911742H&simul=....
+please stay on same base (ex. https://bo.scandpe.fr/ or http://localhost:5174)
+
+---
+
+**Cursor**
+
+I'll update the Save As redirect in the simul app to build the target URL from the current origin and directory path, ensuring it stays on the same base across environments. Then I'll lint the file.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        if (cancelled) return;
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await waitForAccessToken(15000, 250);
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+        if (cancelled) return;
+
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    run();
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh") { run(); }
+      } catch {}
+    });
+    return () => { try { (removeHub as any)?.(); } catch {}; cancelled = true; };
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const cdEnv = ((import.meta as any)?.env?.VITE_CD_ENV as string | undefined) || (import.meta.env.MODE === "development" ? "dev" : "prod");
+                      const suggested = `${cdEnv}_simul_${simulLog || "test0001"}`;
+                      const name = window.prompt(
+                        "Save as name (format: <CD_ENV>_simul_<name>, e.g., dev_simul_test0001):",
+                        suggested
+                      );
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                        if (refAdeme) {
+                          const { origin, pathname } = window.location;
+                          const basePath = (() => {
+                            try {
+                              const idx = pathname.lastIndexOf("/");
+                              return idx !== -1 ? pathname.slice(0, idx + 1) : "/";
+                            } catch {
+                              return "/";
+                            }
+                          })();
+                          const targetUrl = `${origin}${basePath}index.html?ref_ademe=${encodeURIComponent(refAdeme)}&simul=${encodeURIComponent(name)}`;
+                          window.location.href = targetUrl;
+                        }
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+- Save As redirect now keeps the same base. It uses the current origin and directory to build: `{origin}{currentDir}/index.html?ref_ademe=...&simul=...`.
+- Works for both `https://bo.scandpe.fr/...` and `http://localhost:5174/...` without hardcoding the host.
+

--- a/apps/simul/package.json
+++ b/apps/simul/package.json
@@ -17,7 +17,8 @@
     "@ant-design/icons": "^6.0.2",
     "@acme/top-menu": "workspace:*",
     "@acme/simulation-scenarios": "workspace:*",
-    "@acme/dpe-editor": "workspace:*"
+    "@acme/dpe-editor": "workspace:*",
+    "@acme/load-scenario": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/apps/simul/src/App.tsx
+++ b/apps/simul/src/App.tsx
@@ -648,7 +648,12 @@ export const App: React.FC = () => {
                     <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
                     <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
                       if (isSaving) return;
-                      const name = window.prompt("Save as name:", simulLog || "custom");
+                      const cdEnv = ((import.meta as any)?.env?.VITE_CD_ENV as string | undefined) || (import.meta.env.MODE === "development" ? "dev" : "prod");
+                      const suggested = `${cdEnv}_simul_${simulLog || "test0001"}`;
+                      const name = window.prompt(
+                        "Save as name (format: <CD_ENV>_simul_<name>, e.g., dev_simul_test0001):",
+                        suggested
+                      );
                       if (!name) { setIsSaveMenuOpen(false); return; }
                       try {
                         const ref = `${refAdeme || "unknown"}-${name}`;
@@ -671,6 +676,19 @@ export const App: React.FC = () => {
                           throw new Error(`HTTP ${res.status} ${txt}`);
                         }
                         message.success(`saved ${name}`);
+                        if (refAdeme) {
+                          const { origin, pathname } = window.location;
+                          const basePath = (() => {
+                            try {
+                              const idx = pathname.lastIndexOf("/");
+                              return idx !== -1 ? pathname.slice(0, idx + 1) : "/";
+                            } catch {
+                              return "/";
+                            }
+                          })();
+                          const targetUrl = `${origin}${basePath}index.html?ref_ademe=${encodeURIComponent(refAdeme)}&simul=${encodeURIComponent(name)}`;
+                          window.location.href = targetUrl;
+                        }
                       } catch {
                         message.error("save failed");
                       } finally {

--- a/cursor-chat/250923_03_right_click_scope.md
+++ b/cursor-chat/250923_03_right_click_scope.md
@@ -1,0 +1,3533 @@
+# Show tooltip with formatted json on hover
+_Exported on 23/09/2025 at 8:20:01 CEST from Cursor (1.5.5)_
+
+---
+
+**User**
+
+when mouse hover elements in scope (like mur1, mur2, etc.) => show a tooltip with all infos (formatted json) you have about this scope item
+
+---
+
+**Cursor**
+
+I'll scan the editor code to find where scope elements (e.g., mur1/mur2) are rendered and how hover events are handled, then wire a tooltip that shows formatted JSON for the hovered item.
+
+I'll add an Ant Design Tooltip around each scope item description in `DpeDrawerEditor.tsx`, showing a formatted JSON with the item's details and payload on hover, and update imports accordingly.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input, Tooltip } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ fontWeight: 500, marginBottom: 6 }}>Scope</div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const tooltipData = { index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <Tooltip
+                            mouseEnterDelay={0.15}
+                            title={
+                              <div style={{ maxWidth: 640 }}>
+                                <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{JSON.stringify(tooltipData, null, 2)}
+                                </pre>
+                              </div>
+                            }
+                          >
+                            <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                          </Tooltip>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+I wrapped each scope option label with a tooltip that shows the full JSON details for that item on hover.
+
+- You can hover over the description (e.g., “Mur 1 …”) in the Scope list to see a formatted JSON containing: `index`, `key`, `selected`, and the raw `payload` for that scope.
+
+Key edits:
+- Imported `Tooltip` from `antd` in `packages/dpe-editor/src/ui/DpeDrawerEditor.tsx`.
+- Built `tooltipData = { index, key, selected, payload }` per option and displayed it via `<Tooltip>` around the description span, with a `<pre>` to keep formatting.
+
+Status: Implemented and lint-clean.
+
+---
+
+**User**
+
+no tooltip just right-click on item and "details" a modal with json things
+
+---
+
+**Cursor**
+
+Adding a right-click context handler to each scope item to open a modal showing its JSON details, and removing the previous tooltip implementation.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ fontWeight: 500, marginBottom: 6 }}>Scope</div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+Right-click on a scope item now opens a Details modal showing its JSON; the hover tooltip is removed.
+
+- Context menu: On any scope label, right-click to open the modal. It includes `variant`, `collection`, `itemKey`, `index`, `key`, `selected`, and the raw `payload`.
+- Close the modal with the Close button or ESC.
+
+Changes:
+- Removed `Tooltip` import/usage.
+- Added `detailsModal` state and a modal at the bottom of `DpeDrawerEditor.tsx`.
+- Added `onContextMenu` handler on each scope `<label>` to open the details.
+
+---
+
+**User**
+
+after Scope title, a discreet label :"right click" for details
+
+---
+
+**Cursor**
+
+I'll add a small grey hint next to the Scope title that reads: "right click" for details. Now I'll update the JSX accordingly.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask={false}
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+Added a subtle hint next to the Scope title: "right click" for details. It’s grey and small, and the right-click Details modal remains unchanged.
+

--- a/cursor-chat/250923_04_simul_default.md
+++ b/cursor-chat/250923_04_simul_default.md
@@ -1,0 +1,4692 @@
+# Loading simul with default parameters
+_Exported on 23/09/2025 at 18:15:55 CEST from Cursor (1.5.5)_
+
+---
+
+**User**
+
+when simul is being loaded with "simul=default" in URL
+call template endpoint (use template example )
+@template_example.json 
+
+parameters part is not included in json initialized but "input_forced" is added to each scenario input
+
+---
+
+**Cursor**
+
+I'll look for where the simul app initializes and reads URL params, and where API calls for templates would live, to wire the "simul=default" behavior.
+
+I'll locate and read the simul app's `App.tsx` to implement the new URL handling and transformation using `template_example.json`.
+
+I'll add a template-fetch on simul=default with transformation to merge `parameters.input_forced` into each scenario's `input`, and initialize the editor with the transformed runs array. Then I'll run a linter check on the modified file.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    (async () => {
+      try {
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        // Skip if user has already typed something
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await getAccessToken();
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+
+        // Accept either { runs: [...] } or direct array
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            // Merge forced first, then scenario input to let explicit scenario values win
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const name = window.prompt("Save as name:", simulLog || "custom");
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    (async () => {
+      try {
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        // Skip if user has already typed something
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await getAccessToken();
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+
+        // Accept either { runs: [...] } or direct array
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            // Merge forced first, then scenario input to let explicit scenario values win
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const name = window.prompt("Save as name:", simulLog || "custom");
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+I added support for simul=default to auto-load the template, merge input_forced into each scenario, and drop parameters.
+
+- I prevented the existing backoffice get_redis_detail fetches when simul=default.
+- I fetch the template via the existing dpe-editor API, then transform it:
+  - Remove run.parameters entirely.
+  - Merge run.parameters.input_forced into each scenario.input.
+  - Initialize the editor with the resulting runs array (jsonText becomes an array, as expected by submit).
+
+Key edits in apps/simul/src/App.tsx:
+```16:16:/Volumes/privateGg/ai-microfront-ant/apps/simul/src/App.tsx
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+```
+
+```156:200:/Volumes/privateGg/ai-microfront-ant/apps/simul/src/App.tsx
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+    ...
+  }, [bridgeAuthenticated]);
+```
+
+```202:287:/Volumes/privateGg/ai-microfront-ant/apps/simul/src/App.tsx
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+    ...
+  }, []);
+```
+
+```288:328:/Volumes/privateGg/ai-microfront-ant/apps/simul/src/App.tsx
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+  ...
+  useEffect(() => {
+    (async () => {
+      try {
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await getAccessToken();
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+
+        const sourceRuns: any[] = Array.isArray(template) ? template : (template && Array.isArray(template.runs) ? template.runs : []);
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {}
+    })();
+  }, [refAdeme]);
+```
+
+Status: I implemented the change and verified no linter errors on `apps/simul/src/App.tsx`.
+
+- To test:
+  - Open simul with `?ref_ademe=...&simul=default`.
+  - It should fetch `/backoffice/simulation_template`, initialize the editor with an array of runs where each scenario has `input_forced` merged into `input`, and no `parameters` present in the JSON.
+
+```typescriptreact
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+```
+
+```typescriptreact
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+    ...
+  }, [bridgeAuthenticated]);
+```
+
+```typescriptreact
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+    ...
+  }, []);
+```
+
+```typescriptreact
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+  ...
+  useEffect(() => {
+    (async () => {
+      try {
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await getAccessToken();
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+
+        const sourceRuns: any[] = Array.isArray(template) ? template : (template && Array.isArray(template.runs) ? template.runs : []);
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {}
+    })();
+  }, [refAdeme]);
+```
+
+---
+
+**User**
+
+when opening 
+http://localhost:5174/simul/index.html?ref_ademe=2592E2257653N&simul=default
+=> i see a call to cognito but no call to template
+
+---
+
+**Cursor**
+
+I'll inspect the simul auth utilities to see how authorizedFetch works and whether it can help fetch the template when tokens are ready. Then I'll update the code to proactively fetch the template upon token availability (via a shared helper and Hub events), instead of only on initial refAdeme change.
+
+I'll update the template-loading effect to wait for a token before fetching, so the call to the template endpoint reliably triggers after Cognito finishes. Then I'll re-run the linter on the file.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    (async () => {
+      try {
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        // Skip if user has already typed something
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await waitForAccessToken(15000, 250);
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+
+        // Accept either { runs: [...] } or direct array
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            // Merge forced first, then scenario input to let explicit scenario values win
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const name = window.prompt("Save as name:", simulLog || "custom");
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import "./amplify";
+import { authorizedFetch, waitForAccessToken, getAccessToken, setBridgeAccessToken } from "./auth";
+import { Hub } from "aws-amplify/utils";
+import { Button, Card, Col, Flex, Input, InputNumber, Row, Select, Space, Typography, message, Spin, Collapse } from "antd";
+import { ExportOutlined } from "@ant-design/icons";
+import { SimulationScenariosModal } from "@acme/simulation-scenarios";
+import { LoadScenarioModal } from "@acme/load-scenario";
+import { DpeDrawerEditor, fetchSimulationTemplateJson } from "@acme/dpe-editor";
+import { TopMenu } from "@acme/top-menu";
+import { fetchAuthSession, getCurrentUser, fetchUserAttributes } from "aws-amplify/auth";
+import { flushSync } from "react-dom";
+
+const { Title, Paragraph } = Typography;
+
+export const App: React.FC = () => {
+  const [jsonText, setJsonText] = useState<string>("{\n  \"items\": []\n}");
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [apiDebug, setApiDebug] = useState<number | undefined>(undefined);
+  const [skip, setSkip] = useState<number>(0);
+  const [limit, setLimit] = useState<number>(0);
+  const [numChunks, setNumChunks] = useState<number>(1);
+  const [numWorkers, setNumWorkers] = useState<number>(1);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [bridgeReady, setBridgeReady] = useState<boolean>(false);
+  const [bridgeAuthenticated, setBridgeAuthenticated] = useState<boolean>(false);
+  const hasInitFetchedRef = useRef<boolean>(false);
+  const hasUserEditedRef = useRef<boolean>(false);
+  const [refAdeme, setRefAdeme] = useState<string | undefined>(undefined);
+  const [simulLog, setSimulLog] = useState<string | undefined>(undefined);
+  const [isSaveMenuOpen, setIsSaveMenuOpen] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [resultsUrl, setResultsUrl] = useState<string | undefined>(undefined);
+  const activePollAbortRef = useRef<{ cancel: () => void } | null>(null);
+  const [isPolling, setIsPolling] = useState<boolean>(false);
+  const [isScenariosOpen, setIsScenariosOpen] = useState<boolean>(false);
+  const [isLoadSavedOpen, setIsLoadSavedOpen] = useState<boolean>(false);
+  const [isEditorOpen, setIsEditorOpen] = useState<boolean>(false);
+  function openEditor() { setIsEditorOpen(true); }
+  const hasLoadedTemplateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+    // Listen to session bridge messages from auth app
+    function onMessage(ev: MessageEvent) {
+      try {
+        const payload = ev.data;
+        if (!payload || payload.type !== "cognito-session-bridge") return;
+        const authOrigin = payload?.data?.authOrigin as string | undefined;
+        // Optionally validate origin
+        if (authOrigin && !ev.origin.startsWith(authOrigin)) {
+          // origin mismatch – ignore
+          return;
+        }
+        setBridgeReady(true);
+        const isAuthenticated = Boolean(payload?.data?.isAuthenticated);
+        const tokenFromBridge = (payload?.data?.accessToken as string | undefined) || undefined;
+        if (tokenFromBridge) setBridgeAccessToken(tokenFromBridge);
+        if (isAuthenticated) setBridgeAuthenticated(true);
+        const emailFromBridge = (payload?.data?.email as string | undefined) || (payload?.data?.username as string | undefined);
+        if (!isCancelled && emailFromBridge) {
+          setUserEmail((prev) => prev || emailFromBridge);
+        }
+      } catch {}
+    }
+    window.addEventListener("message", onMessage);
+    
+    (async () => {
+      try {
+        const url = new URL(window.location.href);
+        const ra = url.searchParams.get("ref_ademe") || undefined;
+        const sim = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string | undefined) || undefined;
+        if (!isCancelled) {
+          setRefAdeme(ra);
+          setSimulLog(sim);
+        }
+      } catch {}
+      // Immediate cookie-based fallback for username/email
+      try {
+        const parts = document.cookie.split("; ").filter(Boolean);
+        for (const part of parts) {
+          const idx = part.indexOf("=");
+          if (idx === -1) continue;
+          const key = part.substring(0, idx);
+          const val = part.substring(idx + 1);
+          if (key.startsWith("CognitoIdentityServiceProvider.") && key.endsWith(".LastAuthUser")) {
+            const raw = decodeURIComponent(val);
+            if (raw && !isCancelled) {
+              setUserEmail(raw);
+              return; // found username from cookie; stop here
+            }
+          }
+        }
+      } catch {}
+
+      // Fallback #2: decode idToken cookie to extract email claim
+      try {
+        const all = document.cookie.split("; ").filter(Boolean);
+        const prefix = "CognitoIdentityServiceProvider.";
+        for (const cookie of all) {
+          const eq = cookie.indexOf("=");
+          if (eq === -1) continue;
+          const name = cookie.substring(0, eq);
+          if (!name.startsWith(prefix) || !name.endsWith(".idToken")) continue;
+          const raw = decodeURIComponent(cookie.substring(eq + 1));
+          const parts = raw.split(".");
+          if (parts.length >= 2) {
+            const mid = parts[1]!;
+            const payload = JSON.parse(atob(mid.replace(/-/g, "+").replace(/_/g, "/")));
+            const emailClaim = (payload && (payload.email || payload.username)) as string | undefined;
+            if (emailClaim && !isCancelled) {
+              setUserEmail(emailClaim);
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      try {
+        // Prefer Cognito username (often the email) if available
+        const { username } = await getCurrentUser();
+        if (username && !isCancelled) {
+          setUserEmail(username || undefined);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      // Try fetching user attributes (email) when available
+      try {
+        const attrs = await fetchUserAttributes();
+        const emailAttr = attrs?.email as string | undefined;
+        if (emailAttr && !isCancelled) {
+          setUserEmail(emailAttr);
+          return;
+        }
+      } catch {
+        // ignore and fallback to token claim below
+      }
+
+      try {
+        const session = await fetchAuthSession();
+        const emailClaim = (session as any)?.tokens?.idToken?.payload?.email as string | undefined;
+        if (!isCancelled) setUserEmail(emailClaim ?? undefined);
+      } catch {
+        if (!isCancelled) setUserEmail(undefined);
+      }
+    })();
+    return () => {
+      isCancelled = true;
+      window.removeEventListener("message", onMessage);
+    };
+  }, []);
+
+  // Also try firing when bridge reports authenticated (helps cross-port first load)
+  useEffect(() => {
+    if (!bridgeAuthenticated || hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) return;
+        if (hasInitFetchedRef.current) return;
+        hasInitFetchedRef.current = true;
+        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", refAdeme);
+        apiUrl.searchParams.set("log", simul);
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail (bridge)", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail (bridge)", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed (bridge)", err);
+      }
+    })();
+    return () => controller.abort();
+  }, [bridgeAuthenticated]);
+
+  // On init: if URL contains simul=default, call template endpoint and initialize editor JSON
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        if (cancelled) return;
+        if (hasLoadedTemplateRef.current) return;
+        const url = new URL(window.location.href);
+        const simul = url.searchParams.get("simul");
+        if (simul !== "default") return;
+        if (!refAdeme) return;
+        if (hasUserEditedRef.current) return;
+
+        const accessToken = await waitForAccessToken(15000, 250);
+        if (!accessToken) return;
+
+        const baseUrl = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+        const template = await fetchSimulationTemplateJson<any>({ baseUrl, ref_ademe: refAdeme, accessToken });
+        if (cancelled) return;
+
+        const sourceRuns: any[] = Array.isArray(template)
+          ? template
+          : (template && Array.isArray(template.runs) ? template.runs : []);
+
+        const transformedRuns = sourceRuns.map((run) => {
+          const forced = run?.parameters?.input_forced || {};
+          const scenarios = Array.isArray(run?.scenarios) ? run.scenarios : [];
+          const nextScenarios = scenarios.map((sc: any) => {
+            const baseInput = (sc && sc.input && typeof sc.input === "object") ? sc.input : {};
+            const mergedInput = { ...forced, ...baseInput };
+            return { ...sc, input: mergedInput };
+          });
+          const { parameters, ...rest } = run || {};
+          return { ...rest, scenarios: nextScenarios };
+        });
+
+        if (transformedRuns.length > 0) {
+          hasLoadedTemplateRef.current = true;
+          setJsonText(JSON.stringify(transformedRuns, null, 2));
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    run();
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh") { run(); }
+      } catch {}
+    });
+    return () => { try { (removeHub as any)?.(); } catch {}; cancelled = true; };
+  }, [refAdeme]);
+
+  // On init: if URL contains ?ref_ademe=..., call backoffice endpoint (Bearer included when available)
+  useEffect(() => {
+    if (hasInitFetchedRef.current) return;
+    const url = new URL(window.location.href);
+    const refAdeme = url.searchParams.get("ref_ademe");
+    const simul = url.searchParams.get("simul") || (import.meta.env.VITE_BACKOFFICE_LOG as string) || "dev_report_o3cl";
+    if (simul === "default") return;
+    if (!refAdeme) return;
+
+    const controller = new AbortController();
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const apiUrl = new URL("/backoffice/get_redis_detail", base);
+    apiUrl.searchParams.set("ref_ademe", refAdeme);
+    apiUrl.searchParams.set("log", simul);
+
+    async function doFetchOnce() {
+      if (hasInitFetchedRef.current) return;
+      hasInitFetchedRef.current = true;
+      try {
+        // eslint-disable-next-line no-console
+        console.debug("[simulation] calling get_redis_detail", apiUrl.toString());
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json().catch(() => null);
+        if (data && !hasUserEditedRef.current) {
+          setJsonText(JSON.stringify(data, null, 2));
+        }
+        // eslint-disable-next-line no-console
+        console.log("get_redis_detail", data);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    }
+
+    (async () => {
+      try {
+        // Wait for a valid access token before calling the endpoint
+        const token = await waitForAccessToken(15000, 250);
+        if (!token) {
+          // eslint-disable-next-line no-console
+          console.warn("[simulation] skipping get_redis_detail: no Cognito token available");
+          return; // we'll rely on auth Hub events below if sign-in happens later
+        }
+        await doFetchOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("get_redis_detail failed", err);
+      }
+    })();
+
+    const removeHub = Hub.listen("auth", (capsule) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const event = (capsule as any)?.payload?.event as string | undefined;
+        if (!event) return;
+        if (event === "signedIn" || event === "tokenRefresh"){ doFetchOnce(); }
+      } catch {}
+    });
+
+    // Poll as a safety net in case Hub events fired before subscribe
+    const pollId = window.setInterval(async () => {
+      try {
+        if (hasInitFetchedRef.current) { window.clearInterval(pollId); return; }
+        const token = await getAccessToken();
+        if (token) {
+          window.clearInterval(pollId);
+          await doFetchOnce();
+        }
+      } catch {}
+    }, 500);
+
+    return () => {
+      try { (removeHub as any)?.(); } catch {}
+      try { window.clearInterval(pollId); } catch {}
+      controller.abort();
+    };
+  }, []);
+
+  const apiDebugOptions = useMemo(() => [
+    { label: "none", value: undefined },
+    { label: "1", value: 1 },
+    { label: "2", value: 2 },
+  ], []);
+
+  useEffect(() => {
+    return () => {
+      try { activePollAbortRef.current?.cancel(); setIsPolling(false); } catch {}
+    };
+  }, []);
+
+  function startPollingForResults(ref: string, log: string) {
+    // cancel any previous polling
+    try { activePollAbortRef.current?.cancel(); } catch {}
+    let cancelled = false;
+    activePollAbortRef.current = { cancel: () => { cancelled = true; setIsPolling(false); } };
+
+    const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+    const resultsHref = `https://bo.scandpe.fr/simulation/index.html?tab=results&dpe=${encodeURIComponent(ref)}`;
+
+    setIsPolling(true);
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const apiUrl = new URL("/backoffice/get_redis_detail", base);
+        apiUrl.searchParams.set("ref_ademe", ref);
+        apiUrl.searchParams.set("log", log);
+        const res = await authorizedFetch(apiUrl.toString(), {
+          method: "GET",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "x-authorization": "dperdition",
+            "Cache-Control": "no-cache",
+            Pragma: "no-cache",
+          },
+        });
+        if (res.ok) {
+          const data = await res.json().catch(() => null);
+          if (data && data.status === "processed") {
+            setResultsUrl(resultsHref);
+            cancelled = true;
+            setIsPolling(false);
+            return;
+          }
+        }
+      } catch {}
+      if (!cancelled) {
+        window.setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  async function handleSaveToBackoffice() {
+    try {
+      if (!refAdeme || !simulLog) {
+        message.error("Missing ref_ademe or simul");
+        setIsSaveMenuOpen(false);
+        return;
+      }
+      const ref = `${refAdeme}-${simulLog}`;
+      const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+      const apiUrl = new URL("/backoffice/redis_file_manage", base);
+      setIsSaving(true);
+      // eslint-disable-next-line no-console
+      console.debug("[simulation] POST redis_file_manage", { url: apiUrl.toString(), ref });
+      const res = await authorizedFetch(apiUrl.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/plain, */*",
+          "x-authorization": "dperdition",
+        },
+        body: JSON.stringify({ ref, text: jsonText }),
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      message.success(`saved ${simulLog}`);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("redis_file_manage failed", err);
+      message.error("save failed");
+    } finally {
+      setIsSaving(false);
+      setIsSaveMenuOpen(false);
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      const parsed = jsonText.trim() ? JSON.parse(jsonText) : {};
+      const baseQuery = {
+        api_debug: Boolean(apiDebug),
+        skip,
+        limit,
+        ref_ademe: refAdeme,
+      } as Record<string, unknown>;
+      const query = { ...baseQuery, runs: parsed } as Record<string, unknown>;
+      const lambdaUrl = (import.meta.env.VITE_SIMULATION_LAMBDA_URL as string) || "https://6vyebgqw4plhmxrewmsgh6yere0bwpos.lambda-url.eu-west-3.on.aws/";
+      const body = {
+        redis_db: 1,
+        task: "tasks.ext_o3cl_managing.direct_scenarios",
+        args: {
+          ref_ademe: refAdeme,
+          query,
+        },
+      };
+      setSubmitting(true);
+      try {
+        // Use plain fetch to avoid adding Authorization header
+        const res = await fetch(lambdaUrl, {
+          method: "POST",
+          headers: {
+            Accept: "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const txt = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status} ${txt}`);
+        }
+        message.success("Submitted simulation");
+        if (refAdeme) {
+          startPollingForResults(refAdeme, "dev_report_o3cl");
+        }
+      } catch (e) {
+        message.error("Failed to submit");
+      } finally {
+        setSubmitting(false);
+        // eslint-disable-next-line no-console
+        console.log("simulation payload", body);
+      }
+    } catch (err) {
+      message.error("Invalid JSON");
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#ffffff", color: "#0b0c0f" }}>
+      <TopMenu
+        authLabel={userEmail || "login / sign-up"}
+        authHref={(() => {
+          const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+          if (configured) {
+            try {
+              const configuredUrl = new URL(configured);
+              const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+              const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+              if (isConfiguredLocal && !isPageLocal) {
+                // ignore local auth URL on non-localhost pages
+              } else {
+                // On non-local hosts, prefer explicit index.html so returnTo is added to the file URL
+                if (!isConfiguredLocal) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  if (!endsWithHtml) {
+                    const base = hasTrailingSlash ? configured.replace(/\/$/, "") : configured;
+                    return base + "/index.html";
+                  }
+                }
+                return configured;
+              }
+            } catch {
+              return configured;
+            }
+          }
+          if (window.location.hostname === "localhost") return "http://localhost:5173";
+          return "/auth/index.html";
+        })()}
+        isAuthenticated={Boolean(userEmail)}
+        centeredTitle={refAdeme}
+        logoutHref={(() => {
+          const domain = (import.meta.env.VITE_COGNITO_DOMAIN_URL as string | undefined)?.replace(/^https?:\/\//, "");
+          if (!domain) return undefined;
+          const clientId = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined;
+          const logoutRedirect = (import.meta.env.VITE_LOGOUT_REDIRECT_URL as string | undefined) || window.location.origin;
+          if (!clientId) return undefined;
+          return `https://${domain}/logout?client_id=${encodeURIComponent(clientId)}&logout_uri=${encodeURIComponent(logoutRedirect)}`;
+        })()}
+      />
+      {/* Invisible iframe to pull session from auth origin when on different ports */}
+      {!bridgeReady && (
+        <iframe
+          src={(() => {
+            const configured = import.meta.env.VITE_AUTH_URL as string | undefined;
+            if (configured) {
+              try {
+                const configuredUrl = new URL(configured);
+                const isConfiguredLocal = ["localhost", "127.0.0.1"].includes(configuredUrl.hostname);
+                const isPageLocal = ["localhost", "127.0.0.1"].includes(window.location.hostname);
+                if (!(isConfiguredLocal && !isPageLocal)) {
+                  const pathname = configuredUrl.pathname || "/";
+                  const endsWithHtml = /\.html$/i.test(pathname);
+                  const hasTrailingSlash = /\/$/.test(pathname);
+                  const base = endsWithHtml ? configured : (hasTrailingSlash ? configured.replace(/\/$/, "") + "/index.html" : configured + "/index.html");
+                  return base;
+                }
+              } catch {
+                return configured.replace(/\/$/, "") + "/index.html";
+              }
+            }
+            if (window.location.hostname === "localhost") return "http://localhost:5173/index.html";
+            return "/auth/index.html";
+          })()}
+          style={{ display: "none" }}
+          title="session-bridge"
+        />
+      )}
+      <div style={{ padding: 24 }}>
+      <Row gutter={[16, 16]}>
+        <Col xs={0} lg={4}></Col>
+        <Col xs={24} lg={16}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+            <Title level={2} style={{ color: "#0b0c0f", margin: 0 }}>Simulation</Title>
+            <Button type="primary" size="large" onClick={openEditor}>Edit</Button>
+          </div>
+          <Paragraph style={{ color: "#4b5563", marginTop: 4 }}>Provide JSON and configure options, then submit.</Paragraph>
+          
+          <Card style={{ background: "#ffffff", borderColor: "#e5e7eb" }} styles={{ body: { padding: 16 } }}>
+            <div style={{ display: "grid" }}>
+              <textarea
+                ref={textAreaRef}
+                value={jsonText}
+                onChange={(e) => { hasUserEditedRef.current = true; setJsonText(e.target.value); }}
+                placeholder="Paste or write JSON here"
+                style={{
+                  minHeight: 420,
+                  width: "100%",
+                  background: isEditorOpen ? "#f3f4f6" : "#ffffff",
+                  color: isEditorOpen ? "#6b7280" : "#111827",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 8,
+                  padding: 12,
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace",
+                  fontSize: 14,
+                  lineHeight: 1.45,
+                  resize: "vertical",
+                  cursor: isEditorOpen ? "default" : "text",
+                  overflow: "auto",
+                }}
+                readOnly={isEditorOpen}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <Collapse
+                destroyOnHidden
+                items={[
+                  {
+                    key: "options",
+                    label: "Options",
+                    children: (
+                      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>api_debug</div>
+                          <Select
+                            value={apiDebug as number | undefined}
+                            onChange={(v) => setApiDebug(v)}
+                            allowClear
+                            placeholder="none"
+                            options={apiDebugOptions}
+                            style={{ width: "100%" }}
+                          />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>skip</div>
+                          <InputNumber value={skip} onChange={(v) => setSkip(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>limit</div>
+                          <InputNumber value={limit} onChange={(v) => setLimit(Number(v ?? 0))} style={{ width: "100%" }} min={0} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb chunks</div>
+                          <InputNumber value={numChunks} onChange={(v) => setNumChunks(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                        <div>
+                          <div style={{ marginBottom: 6, color: "#4b5563" }}>nb workers</div>
+                          <InputNumber value={numWorkers} onChange={(v) => setNumWorkers(Number(v ?? 1))} style={{ width: "100%" }} min={1} />
+                        </div>
+                      </Space>
+                    ),
+                  },
+                ]}
+              />
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", alignItems: "center" }}>
+                <Button type="primary" onClick={handleSubmit} loading={submitting}>submit</Button>
+                <div style={{ position: "relative" }}>
+                  <Button onClick={() => setIsSaveMenuOpen((v) => !v)}>...</Button>
+                  {isSaveMenuOpen && (
+                    <div style={{ position: "absolute", right: 0, top: "100%", background: "#fff", border: "1px solid #e5e7eb", borderRadius: 8, padding: 8, width: 260, boxShadow: "0 4px 14px rgba(0,0,0,0.08)", zIndex: 10 }}>
+                    <div style={{ padding: "6px 8px", cursor: "pointer", borderRadius: 6 }} onClick={() => { setIsLoadSavedOpen(true); setIsSaveMenuOpen(false); }}>load scenario</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={() => { if (!isSaving) handleSaveToBackoffice(); }}>save {simulLog || "default"}</div>
+                    <div style={{ height: 1, background: "#e5e7eb", margin: "6px 0" }} />
+                    <div style={{ padding: "6px 8px", cursor: isSaving ? "default" : "pointer", opacity: isSaving ? 0.6 : 1, borderRadius: 6 }} onClick={async () => {
+                      if (isSaving) return;
+                      const name = window.prompt("Save as name:", simulLog || "custom");
+                      if (!name) { setIsSaveMenuOpen(false); return; }
+                      try {
+                        const ref = `${refAdeme || "unknown"}-${name}`;
+                        const base = (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr";
+                        const apiUrl = new URL("/backoffice/redis_file_manage", base);
+                        setIsSaving(true);
+                        // eslint-disable-next-line no-console
+                        console.debug("[simulation] POST redis_file_manage (save as)", { url: apiUrl.toString(), ref });
+                        const res = await authorizedFetch(apiUrl.toString(), {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            Accept: "application/json, text/plain, */*",
+                            "x-authorization": "dperdition",
+                          },
+                          body: JSON.stringify({ ref, text: jsonText }),
+                        });
+                        if (!res.ok) {
+                          const txt = await res.text().catch(() => "");
+                          throw new Error(`HTTP ${res.status} ${txt}`);
+                        }
+                        message.success(`saved ${name}`);
+                      } catch {
+                        message.error("save failed");
+                      } finally {
+                        setIsSaving(false);
+                        setIsSaveMenuOpen(false);
+                      }
+                    }}>save as…</div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "flex", justifyContent: "flex-end", minHeight: 24 }}>
+                {!resultsUrl && isPolling && (
+                  <Spin size="small" />
+                )}
+                {resultsUrl && (
+                  <a href={resultsUrl} target="_blank" rel="noopener noreferrer" style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                    Open simulation results <ExportOutlined />
+                  </a>
+                )}
+              </div>
+              <DpeDrawerEditor
+                open={isEditorOpen}
+                onClose={() => setIsEditorOpen(false)}
+                width="50%"
+                rootJsonText={jsonText}
+                onApply={(next) => { hasUserEditedRef.current = true; flushSync(() => setJsonText(next)); }}
+                apiLoadParams={refAdeme ? { baseUrl: (import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr", ref_ademe: refAdeme } : undefined}
+                getAccessToken={getAccessToken}
+                onLoadedFromApi={(data) => {
+                  try {
+                    const text = JSON.stringify(data, null, 2);
+                    setJsonText((prev) => (prev?.trim() ? prev : text));
+                  } catch {}
+                }}
+                onHighlightJsonPath={({ collection, itemKey, indices }) => {
+                  try {
+                    const ta = textAreaRef.current;
+                    if (!ta) return;
+                    const text = ta.value;
+                    // New highlight strategy: target the runs entry with elements_variant, then the elements_scope array
+                    const variantPath = `dpe.logement.enveloppe.${collection}.${itemKey}`;
+                    const variantKeyIdx = text.indexOf('"elements_variant"');
+                    let searchFrom = 0;
+                    let entryStart = -1;
+                    let scopeArrayStart = -1;
+                    let scopeArrayEnd = -1;
+                    // Scan for the entry containing the variantPath
+                    while (true) {
+                      const varIdx = text.indexOf('"elements_variant"', searchFrom);
+                      if (varIdx === -1) break;
+                      const quoteIdx = text.indexOf('"', varIdx + 18);
+                      const quoteEnd = quoteIdx !== -1 ? text.indexOf('"', quoteIdx + 1) : -1;
+                      const value = quoteIdx !== -1 && quoteEnd !== -1 ? text.slice(quoteIdx + 1, quoteEnd) : '';
+                      if (value === variantPath) {
+                        // Backtrack to entry start '{'
+                        let i = varIdx;
+                        while (i >= 0 && text[i] !== '{') i--;
+                        entryStart = i >= 0 ? i : varIdx;
+                        // Find elements_scope within this entry
+                        const scopeKeyIdx = text.indexOf('"elements_scope"', varIdx);
+                        if (scopeKeyIdx !== -1) {
+                          const openBracket = text.indexOf('[', scopeKeyIdx);
+                          if (openBracket !== -1) {
+                            scopeArrayStart = openBracket;
+                            // find matching closing bracket (not perfect but ok for flat arrays)
+                            const closeBracket = text.indexOf(']', openBracket);
+                            if (closeBracket !== -1) scopeArrayEnd = closeBracket + 1;
+                          }
+                        }
+                        break;
+                      }
+                      searchFrom = varIdx + 1;
+                    }
+                    if (scopeArrayStart === -1 || scopeArrayEnd === -1) return;
+                    const prevSelStart = ta.selectionStart;
+                    const prevSelEnd = ta.selectionEnd;
+                    const prevScrollTop = ta.scrollTop;
+                    const prevScrollLeft = ta.scrollLeft;
+                    try {
+                      // Avoid scrolling when focusing for selection highlight
+                      (ta as any).focus({ preventScroll: true });
+                    } catch {
+                      try { ta.focus(); } catch {}
+                    }
+                    try {
+                      ta.setSelectionRange(scopeArrayStart, scopeArrayEnd);
+                    } catch {}
+                    // Immediately restore scroll so the viewport doesn't jump
+                    try {
+                      ta.scrollTop = prevScrollTop;
+                      ta.scrollLeft = prevScrollLeft;
+                    } catch {}
+                    window.setTimeout(() => {
+                      try {
+                        // Restore previous selection and scroll position without jumping
+                        (ta as any).focus({ preventScroll: true });
+                        ta.setSelectionRange(prevSelStart, prevSelEnd);
+                        ta.scrollTop = prevScrollTop;
+                        ta.scrollLeft = prevScrollLeft;
+                      } catch {}
+                    }, 600);
+                  } catch {}
+                }}
+              />
+            </div>
+            <SimulationScenariosModal
+              open={isScenariosOpen}
+              onCancel={() => setIsScenariosOpen(false)}
+              onLoad={(runs) => {
+                try {
+                  setJsonText(JSON.stringify(runs, null, 2));
+                } catch {
+                  // fallback to empty array
+                  setJsonText(JSON.stringify([], null, 2));
+                }
+                setIsScenariosOpen(false);
+              }}
+            />
+            <LoadScenarioModal
+              open={isLoadSavedOpen}
+              onCancel={() => setIsLoadSavedOpen(false)}
+              onSelect={(payload: unknown) => {
+                try {
+                  // Accept payload either as normalized object { ref_ademe, label } or string "ref:label"
+                  let ref: string | undefined;
+                  let simul: string | undefined;
+                  if (typeof payload === "string") {
+                    const colon = payload.indexOf(":");
+                    ref = colon !== -1 ? payload.slice(0, colon) : undefined;
+                    simul = colon !== -1 ? payload.slice(colon + 1) : undefined;
+                  } else if (payload && typeof payload === "object") {
+                    ref = (payload as any).ref_ademe as string | undefined;
+                    simul = (payload as any).label as string | undefined;
+                  }
+                  const url = new URL(window.location.href);
+                  if (ref) url.searchParams.set("ref_ademe", ref);
+                  if (simul) url.searchParams.set("simul", simul);
+                  window.location.href = url.toString();
+                } catch {}
+                setIsLoadSavedOpen(false);
+              }}
+              baseUrl={(import.meta.env.VITE_BACKOFFICE_API_URL as string) || "https://api-dev.etiquettedpe.fr"}
+              initialRefAdeme={refAdeme}
+              getAccessToken={getAccessToken}
+            />
+          </Card>
+        </Col>
+        <Col xs={0} lg={4}></Col>
+
+      </Row>
+      </div>
+    </div>
+  );
+};
+
+
+
+```
+
+- I added a token-aware template loader: when `simul=default` and `ref_ademe` are present, the app now waits for a Cognito access token, then calls `/backoffice/simulation_template`.
+- I hooked it to both initial mount and auth Hub events (`signedIn`/`tokenRefresh`) to ensure the call fires once the token is ready.
+- I also disabled the previous `get_redis_detail` fetch when `simul=default` to avoid conflicts.
+- The returned template is transformed to:
+  - remove `parameters`
+  - merge `parameters.input_forced` into each scenario’s `input`
+  - and initialize the editor with the resulting runs array.
+
+Try again at:
+- `http://localhost:5174/simul/index.html?ref_ademe=2592E2257653N&simul=default`
+You should now see a call to the template endpoint after Cognito finishes.
+
+---
+
+**User**
+
+cool.
+when i click outside the right drawer, would you have similar behavior than close? (also ask for discard if necessary) ?
+
+---
+
+**Cursor**
+
+I'll look into the `DpeDrawerEditor` component to see how it handles closing and mask clicks, and then add a confirmation prompt on outside clicks if there are unsaved changes.
+
+I'll enable closing the editor on outside clicks by turning on the mask for the right drawer. Mask clicks will now trigger the same close handler, which already prompts to discard changes if needed. I'll make the edit and check for linter issues.
+
+```typescriptreact
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, Checkbox, Drawer, Space, Switch, message, InputNumber, Modal, Input } from "antd";
+import { fetchSimulationDpeFullJson, fetchSimulationTemplateJson } from "../api";
+
+export type DpeDrawerEditorProps = {
+  open: boolean;
+  onClose: () => void;
+  width?: number | string;
+  rootJsonText: string;
+  onApply: (nextJsonText: string) => void;
+  // When provided, component will call the API on open using a Cognito bearer token
+  apiLoadParams?: { baseUrl?: string; ref_ademe: string };
+  getAccessToken?: () => Promise<string | null>;
+  onLoadedFromApi?: (data: unknown) => void;
+  onHighlightJsonPath?: (args: { collection: string; itemKey: string; indices: number[] }) => void;
+};
+
+type VariantId = string; // e.g. "dpe.logement.enveloppe.mur_collection.mur"
+type EditorVariantState = { enabled: boolean; index: number; text: string };
+type VariantDef = { id: VariantId; collection: string; itemKey: string; label: string };
+
+function parseVariantPath(path: string): { collection: string; itemKey: string } | null {
+  try {
+    const parts = path.split(".");
+    const idx = parts.lastIndexOf("enveloppe");
+    if (idx === -1) return null;
+    const collection = parts[idx + 1];
+    const itemKey = parts[idx + 2];
+    if (!collection || !itemKey) return null;
+    return { collection, itemKey };
+  } catch {
+    return null;
+  }
+}
+
+function toLabel(input: string): string {
+  const spaced = input.replace(/_/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function deepGet(root: any, path: (string | number)[]): any {
+  return path.reduce((acc: any, key: any) => (acc != null ? acc[key] : undefined), root);
+}
+
+function ensurePath(root: any, path: string[]): any {
+  let cursor = root;
+  for (const key of path) {
+    if (cursor[key] == null || typeof cursor[key] !== "object") {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose, width = "50%", rootJsonText, onApply, apiLoadParams, getAccessToken, onLoadedFromApi, onHighlightJsonPath }) => {
+  const [availableOptions, setAvailableOptions] = useState<Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]>>({});
+  const [highlighted, setHighlighted] = useState<Record<VariantId, Record<string, boolean>>>({});
+  const [pricing, setPricing] = useState<Record<VariantId, { increments: number[]; priceVar: number[]; priceFix: number[]; incrementUnit: string; priceUnit: string }>>({});
+
+  const [colSettings, setColSettings] = useState<{ open: boolean; variant: VariantId | null; field: "increments" | "priceVar" | "priceFix" | null; tempUnit: string; tempKey: string; tempForcedInputs: string }>({
+    open: false,
+    variant: null,
+    field: null,
+    tempUnit: "",
+    tempKey: "",
+    tempForcedInputs: "",
+  });
+
+  const [mappingKeys, setMappingKeys] = useState<Record<VariantId, { inputKey?: string; costKey?: string }>>({});
+  const [forcedInputs, setForcedInputs] = useState<Record<VariantId, string>>({});
+  const originalJsonRef = useRef<string>("");
+  const [scenarioEnabled, setScenarioEnabled] = useState<Record<VariantId, boolean[]>>({});
+  const [scopeStrategy, setScopeStrategy] = useState<Record<VariantId, "all" | "explode">>({});
+  const [templateRuns, setTemplateRuns] = useState<any[]>([]);
+  const [templateDerived, setTemplateDerived] = useState<Record<VariantId, { increments: number[]; priceVar: number[] }>>({});
+  const [templateScenarioIds, setTemplateScenarioIds] = useState<Record<VariantId, number[]>>({});
+  const [detailsModal, setDetailsModal] = useState<{ open: boolean; title: string; data: any }>({ open: false, title: "", data: null });
+
+  const variantDefs: VariantDef[] = useMemo(() => {
+    const map = new Map<VariantId, VariantDef>();
+    try {
+      // From template runs
+      const runsTpl: any[] = Array.isArray(templateRuns) ? templateRuns : [];
+      for (const r of runsTpl) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const parsed = parseVariantPath(ev);
+          if (parsed) {
+            const { collection, itemKey } = parsed;
+            const label = toLabel(itemKey);
+            map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    try {
+      // From current JSON text (runs array)
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const r of runs) {
+        const ev = r?.elements_variant;
+        if (typeof ev === "string") {
+          const p = parseVariantPath(ev);
+          if (p) {
+            const { collection, itemKey } = p;
+            const label = toLabel(itemKey);
+            if (!map.has(ev)) map.set(ev, { id: ev, collection, itemKey, label });
+          }
+        }
+      }
+    } catch {}
+    return Array.from(map.values());
+  }, [templateRuns, rootJsonText]);
+
+  const variantIds: VariantId[] = useMemo(() => variantDefs.map((v) => v.id), [variantDefs]);
+
+  // Ensure state maps have defaults for discovered variants
+  useEffect(() => {
+    if (!variantIds.length) return;
+    setPricing((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) {
+        if (!next[id]) next[id] = { increments: [0, 10, 30], priceVar: [0, 100, 150], priceFix: [0, 0, 0], incrementUnit: "cm", priceUnit: "EUR/m2" };
+      }
+      return next;
+    });
+    setMappingKeys((prev) => ({ ...prev }));
+    setForcedInputs((prev) => {
+      const next = { ...prev };
+      for (const id of variantIds) if (next[id] == null) next[id] = "{\n}\n";
+      return next;
+    });
+    setScenarioEnabled((prev) => ({ ...prev }));
+    setScopeStrategy((prev) => {
+      const next = { ...prev } as Record<VariantId, "all" | "explode">;
+      for (const id of variantIds) if (!next[id]) next[id] = "all";
+      return next;
+    });
+    setTemplateDerived((prev) => ({ ...prev }));
+    setTemplateScenarioIds((prev) => ({ ...prev }));
+    setAvailableOptions((prev) => ({ ...prev }));
+    setHighlighted((prev) => ({ ...prev }));
+  }, [variantIds]);
+  // Fetch from API when the drawer opens if configured
+  useEffect(() => {
+    if (!open || !apiLoadParams || !getAccessToken) return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token) return;
+        const [data, template]: any[] = await Promise.all([
+          fetchSimulationDpeFullJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+          fetchSimulationTemplateJson({
+            baseUrl: apiLoadParams.baseUrl,
+            ref_ademe: apiLoadParams.ref_ademe,
+            accessToken: token,
+          }),
+        ]);
+        if (!isCancelled) {
+          onLoadedFromApi?.(data);
+          try {
+            // Derive current scopes from JSON if present to preselect options
+            let parsed: any = [];
+            try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+            const runs: any[] = Array.isArray(parsed) ? parsed : [];
+            const optionsMap: Record<VariantId, { key: string; description: string; selected: boolean; payload: any }[]> = {};
+            const envelope = (data as any)?.dpe?.logement?.enveloppe || {};
+            for (const v of variantDefs) {
+              const entry = runs.find((r) => r && r.elements_variant === v.id);
+              const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+              const collectionObj = envelope?.[v.collection];
+              let items: any[] = [];
+              if (Array.isArray(collectionObj?.[v.itemKey])) {
+                items = collectionObj[v.itemKey] as any[];
+              } else if (Array.isArray(collectionObj)) {
+                // Shape B: array of slots { <itemKey>: {...} }
+                items = (collectionObj as any[]).map((slot) => (slot && typeof slot === "object" ? slot[v.itemKey] : undefined)).filter(Boolean);
+              }
+              optionsMap[v.id] = (items || []).map((item: any, idx: number) => ({
+                key: String(item?.donnee_entree?.reference || idx),
+                description: String(item?.donnee_entree?.description || `${toLabel(v.itemKey)} ${idx + 1}`),
+                selected: scopes.includes(idx),
+                payload: item,
+              }));
+            }
+            setAvailableOptions(optionsMap);
+
+            // Seed defaults from template: parameters.unit and parameters.input_forced per elements_variant
+            try {
+              const runsTpl: any[] = Array.isArray(template?.runs) ? template.runs : [];
+              setTemplateRuns(runsTpl);
+              for (const v of variantDefs) {
+                const tplEntry = runsTpl.find((r) => r && r.elements_variant === v.id) || {};
+                const params = tplEntry.parameters || {};
+                const unit = typeof params.unit === "string" ? params.unit : undefined;
+                if (unit) {
+                  setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+                }
+                const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+                if (forced) {
+                  try {
+                    const pretty = JSON.stringify(forced, null, 2) + "\n";
+                    setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+                  } catch {}
+                }
+              }
+            } catch {}
+          } catch {
+            setAvailableOptions({});
+          }
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          // eslint-disable-next-line no-console
+          console.error("DpeDrawerEditor: failed to load from API", err);
+          message.error("Failed to load initial data");
+        }
+      }
+    })();
+    return () => { isCancelled = true; };
+  }, [open, apiLoadParams?.baseUrl, apiLoadParams?.ref_ademe, getAccessToken, onLoadedFromApi]);
+
+  // Keep checkbox selections in sync with current JSON (runs array) in the editor
+  useEffect(() => {
+    try {
+      const parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      setAvailableOptions((prev) => {
+        const next: typeof prev = { ...prev };
+        for (const v of variantDefs) {
+          const entry = runs.find((r) => r && r.elements_variant === v.id);
+          const scopes: number[] = Array.isArray(entry?.elements_scope) ? (entry.elements_scope as number[]) : [];
+          next[v.id] = (prev[v.id] || []).map((o, idx) => ({ ...o, selected: scopes.includes(idx) }));
+        }
+        return next;
+      });
+    } catch {
+      // ignore
+    }
+  }, [rootJsonText, variantDefs]);
+
+  // Capture original JSON when opening, used to rollback on close (X)
+  useEffect(() => {
+    if (open) {
+      originalJsonRef.current = rootJsonText;
+    }
+  }, [open]);
+
+  // (no-op)
+
+  // Sync scope strategy from JSON (default to "all")
+  useEffect(() => {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const next: Record<VariantId, "all" | "explode"> = {};
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        next[v.id] = entry?.scope_strategy === "explode" ? "explode" : "all";
+      }
+      setScopeStrategy(next);
+    } catch {
+      // ignore
+    }
+  }, [open, rootJsonText, variantDefs]);
+
+  function deriveVariantPricingFromRuns(runsArr: any[], variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Derive template-based values for disabled scenarios
+  useEffect(() => {
+    try {
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricingFromRuns(templateRuns, v.id);
+        setTemplateDerived((prev) => ({ ...prev, [v.id]: derived }));
+        const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === v.id) || {};
+        const ids = Array.isArray(entry?.scenarios) ? entry.scenarios.map((sc: any) => Number(sc?.id)).filter((n: any) => Number.isFinite(n)) : [];
+        setTemplateScenarioIds((prev) => ({ ...prev, [v.id]: ids }));
+      }
+    } catch {}
+  }, [templateRuns, mappingKeys, variantDefs]);
+
+  function getPresentScenarioIds(variantId: VariantId): number[] {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      return scenarios.map((sc) => Number(sc?.id)).filter((n) => Number.isFinite(n));
+    } catch {
+      return [];
+    }
+  }
+
+  const initialState = useMemo((): Record<VariantId, EditorVariantState> => {
+    try {
+      const rootRaw = rootJsonText.trim() ? JSON.parse(rootJsonText) : [];
+      const runsArr: any[] = Array.isArray(rootRaw) ? rootRaw : [];
+      const next: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) {
+        const hasEntry = runsArr.some((r) => r && r.elements_variant === v.id);
+        next[v.id] = { enabled: Boolean(hasEntry), index: 0, text: "{\n}\n" };
+      }
+      return next;
+    } catch {
+      const fallback: Record<VariantId, EditorVariantState> = {};
+      for (const v of variantDefs) fallback[v.id] = { enabled: false, index: 0, text: "{\n}\n" };
+      return fallback;
+    }
+  }, [rootJsonText, variantDefs]);
+
+  const [editorState, setEditorState] = useState<Record<VariantId, EditorVariantState>>(initialState);
+  useEffect(() => {
+    if (open) {
+      setEditorState(initialState);
+    }
+  }, [open, initialState]);
+
+  // (no-op)
+
+  function applyEditorChanges() {
+    try {
+      let parsedAny: any = rootJsonText.trim() ? JSON.parse(rootJsonText) : {};
+      // If the root is a runs[] array, apply scenario changes there; otherwise apply editor JSON to nested object
+      if (Array.isArray(parsedAny)) {
+        const runs: any[] = parsedAny as any[];
+        for (const v of variantDefs) {
+          const variantPath = v.id;
+          let entry = runs.find((r) => r && r.elements_variant === variantPath);
+          const hasAnyScenario = (scenarioEnabled[v.id] || []).some(Boolean);
+          if (!entry && hasAnyScenario) {
+            entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: scopeStrategy[v.id] || "all", scenarios: [] };
+            runs.push(entry);
+          }
+          if (!entry) continue;
+          // Keep scope strategy as staged
+          entry.scope_strategy = scopeStrategy[v.id] || entry.scope_strategy || "all";
+          // Remove any UI-only pricing blocks
+          if (entry.pricing) { try { delete entry.pricing; } catch {} }
+          if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+
+          const rowCount = Math.max(
+            pricing[v.id]?.increments.length || 0,
+            pricing[v.id]?.priceVar.length || 0,
+            pricing[v.id]?.priceFix.length || 0,
+            (scenarioEnabled[v.id] || []).length,
+            (templateScenarioIds[v.id] || []).length
+          );
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+
+          for (let idx = 0; idx < rowCount; idx += 1) {
+            const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+            if (enabled) {
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex === -1) targetIndex = idx;
+              while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+              const current = entry.scenarios[targetIndex];
+              const nextSc = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+              if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+              if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+              const templateInc = Number(templateDerived[v.id]?.increments?.[idx] ?? NaN);
+              const pLocal = pricing[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              const incFromState = Number(pLocal.increments[targetIndex] ?? NaN);
+              const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(templateInc) ? templateInc : 0);
+              nextSc.input[configuredInputKey] = { set: incVal };
+              const forcedText = forcedInputs[v.id] || "";
+              try {
+                const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+                if (forcedObj && typeof forcedObj === "object") {
+                  Object.entries(forcedObj).forEach(([fk, fv]) => {
+                    if (fk === configuredInputKey) return;
+                    if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+                  });
+                }
+              } catch {}
+              const templatePriceVar = Number(templateDerived[v.id]?.priceVar?.[idx] ?? NaN);
+              const priceVarFromState = Number(pLocal.priceVar[targetIndex] ?? NaN);
+              const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(templatePriceVar) ? templatePriceVar : 0);
+              nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+              entry.scenarios[targetIndex] = nextSc;
+            } else {
+              // Disabled: remove the scenario object entirely
+              const tplIds = templateScenarioIds[v.id] || [];
+              const idFromTemplate = (tplIds[idx] != null) ? Number(tplIds[idx]) : (idx + 1);
+              const targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+              if (targetIndex !== -1) {
+                entry.scenarios.splice(targetIndex, 1);
+              }
+            }
+          }
+        }
+        onApply(JSON.stringify(runs, null, 2));
+        message.success("Editor changes applied");
+        onClose();
+        return;
+      }
+
+      // Fallback: nested object editing mode stays unchanged
+      const root = parsedAny && typeof parsedAny === "object" ? parsedAny : {};
+      // Nested-object editing path is deprecated in favor of runs[] flow. Kept for backwards compatibility.
+      for (const v of variantDefs) {
+        const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+        const idx = Math.max(0, Math.floor(st.index || 0));
+        const baseObj = ensurePath(root, ["dpe", "logement", "enveloppe"]);
+        if (!Array.isArray((baseObj as any)[v.collection])) {
+          (baseObj as any)[v.collection] = [] as any[];
+        }
+        const arr: any[] = (baseObj as any)[v.collection];
+        if (st.enabled) {
+          let parsed: any = {};
+          try { parsed = st.text.trim() ? JSON.parse(st.text) : {}; } catch {
+            throw new Error(`${v.label}: invalid JSON`);
+          }
+          while (arr.length <= idx) arr.push(null);
+          const nextItem = { [v.itemKey]: parsed } as Record<string, any>;
+          arr[idx] = nextItem;
+        } else {
+          if (Array.isArray(arr) && arr.length > idx) {
+            arr.splice(idx, 1);
+          }
+        }
+      }
+      onApply(JSON.stringify(root, null, 2));
+      message.success("Editor changes applied");
+      onClose();
+    } catch (err: any) {
+      message.error(String(err?.message || err || "Failed to apply changes"));
+    }
+  }
+
+  function handleDrawerClose() {
+    // Close silently if nothing would change; otherwise, confirm discard.
+    try {
+      const originalText = (originalJsonRef.current || "").trim();
+      const currentText = (rootJsonText || "").trim();
+      let isSame = false;
+      try {
+        const originalParsed = originalText ? JSON.parse(originalText) : null;
+        const currentParsed = currentText ? JSON.parse(currentText) : null;
+        isSame = JSON.stringify(originalParsed) === JSON.stringify(currentParsed);
+      } catch {
+        isSame = originalText === currentText;
+      }
+      if (isSame) {
+        onClose();
+        return;
+      }
+    } catch {}
+    Modal.confirm({
+      title: "Discard changes?",
+      content: "Closing will revert any changes made in this panel.",
+      okText: "Discard",
+      cancelText: "Cancel",
+      onOk: () => {
+        try {
+          onApply(originalJsonRef.current);
+        } finally {
+          onClose();
+        }
+      },
+    });
+  }
+
+  function getFirstScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const inputObj = firstScenario?.input || firstScenario?.inputs || undefined;
+      if (inputObj && typeof inputObj === "object") {
+        const keys = Object.keys(inputObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const firstScenario = Array.isArray(entry?.scenarios) && entry.scenarios.length > 0 ? entry.scenarios[0] : undefined;
+      const costObj = firstScenario?.cost || undefined;
+      if (costObj && typeof costObj === "object") {
+        const keys = Object.keys(costObj);
+        return keys.length > 0 ? keys[0] : undefined;
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  }
+
+  function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
+    const empty = { increments: [] as number[], priceVar: [] as number[] };
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      const entry = runs.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      if (!scenarios.length) return empty;
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const increments: number[] = scenarios.map((sc) => {
+        const val = sc?.input?.[inputKey]?.set;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      const priceVar: number[] = scenarios.map((sc) => {
+        const val = sc?.cost?.[costKey]?.multiply;
+        const num = typeof val === "number" ? val : Number(val);
+        return Number.isFinite(num) ? num : 0;
+      });
+      return { increments, priceVar };
+    } catch {
+      return empty;
+    }
+  }
+
+  // Sync pricing grid from JSON scenarios when opening or when JSON/mapping keys change
+  useEffect(() => {
+    if (!open) return;
+    try {
+      // Also sync parameters.unit and parameters.input_forced
+      try {
+        let parsedAll: any = [];
+        try { parsedAll = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsedAll = []; }
+        const runsAll: any[] = Array.isArray(parsedAll) ? parsedAll : [];
+        for (const v of variantDefs) {
+          const entry = runsAll.find((r) => r && r.elements_variant === v.id) || {};
+          const params = entry.parameters || {};
+          const unit = typeof params.unit === "string" ? params.unit : undefined;
+          if (unit) {
+            setPricing((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" }), incrementUnit: unit, priceUnit: prev[v.id]?.priceUnit || "EUR/m2", increments: prev[v.id]?.increments || [], priceVar: prev[v.id]?.priceVar || [], priceFix: prev[v.id]?.priceFix || [] } }));
+          }
+          const forced = params.input_forced && typeof params.input_forced === "object" ? params.input_forced : undefined;
+          if (forced) {
+            try {
+              const pretty = JSON.stringify(forced, null, 2) + "\n";
+              setForcedInputs((prev) => ({ ...prev, [v.id]: pretty }));
+            } catch {}
+          }
+        }
+      } catch {}
+
+      for (const v of variantDefs) {
+        const derived = deriveVariantPricing(v.id);
+        setPricing((prev) => {
+          const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextLen = derived.increments.length || current.increments.length || 0;
+          const ensureLen = (arr: number[], len: number) => {
+            const out = arr.slice(0, len);
+            while (out.length < len) out.push(0);
+            return out;
+          };
+          const nextIncrements = derived.increments.length ? derived.increments : current.increments;
+          const nextPriceVar = derived.priceVar.length ? derived.priceVar : current.priceVar;
+          const nextPriceFix = ensureLen(current.priceFix, Math.max(nextLen, nextPriceVar.length));
+          return {
+            ...prev,
+            [v.id]: { ...current, increments: nextIncrements, priceVar: nextPriceVar, priceFix: nextPriceFix },
+          };
+        });
+      }
+    } catch {}
+  }, [open, rootJsonText, mappingKeys, variantDefs]);
+
+  // Sync scenario enabled flags from JSON
+  useEffect(() => {
+    if (!open) return;
+    try {
+      let parsed: any = [];
+      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+      for (const v of variantDefs) {
+        const entry = runs.find((r) => r && r.elements_variant === v.id);
+        const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+        const flags = scenarios.map((sc) => Boolean(sc && typeof sc === "object"));
+        setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+      }
+    } catch {}
+  }, [open, rootJsonText, variantDefs]);
+
+  // Initialize scenarioEnabled by comparing template scenario ids with JSON presence (by id)
+  useEffect(() => {
+    if (!open) return;
+    try {
+      for (const v of variantDefs) {
+        const presentIds = new Set<number>(getPresentScenarioIds(v.id));
+        const ids = templateScenarioIds[v.id] || [];
+        const flags = ids.map((id) => presentIds.has(Number(id)));
+        if (ids.length) {
+          setScenarioEnabled((prev) => ({ ...prev, [v.id]: flags }));
+        }
+      }
+    } catch {}
+  }, [open, rootJsonText, templateScenarioIds, variantDefs]);
+
+  function toggleScenarioPresence(variantId: VariantId, idx: number, enabled: boolean) {
+    try {
+      if (enabled) {
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        let entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (!entry) {
+          entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: (scopeStrategy[variantId] || "all"), scenarios: [] };
+          runs.push(entry);
+        }
+        if (!Array.isArray(entry.scenarios)) entry.scenarios = [];
+        const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+          ? Number(templateScenarioIds[variantId][idx])
+          : (idx + 1);
+        let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+        if (targetIndex === -1) targetIndex = entry.scenarios.findIndex((sc: any) => sc == null);
+        if (targetIndex === -1) targetIndex = entry.scenarios.length;
+        while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
+        const current = entry.scenarios[targetIndex];
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
+        if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
+        if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
+        const tmplInc = Number(templateDerived[variantId]?.increments?.[idx] ?? NaN);
+        const incFromState = Number(pricing[variantId]?.increments?.[targetIndex] ?? NaN);
+        const incVal = Number.isFinite(incFromState) ? incFromState : (Number.isFinite(tmplInc) ? tmplInc : 0);
+        nextSc.input[configuredInputKey] = { set: incVal };
+        try {
+          const forcedText = forcedInputs[variantId] || "";
+          const forcedObj = forcedText.trim() ? JSON.parse(forcedText) : {};
+          if (forcedObj && typeof forcedObj === "object") {
+            Object.entries(forcedObj).forEach(([fk, fv]) => {
+              if (fk === configuredInputKey) return;
+              if (nextSc.input[fk] == null) nextSc.input[fk] = fv;
+            });
+          }
+        } catch {}
+        const tmplPriceVar = Number(templateDerived[variantId]?.priceVar?.[idx] ?? NaN);
+        const priceVarFromState = Number(pricing[variantId]?.priceVar?.[targetIndex] ?? NaN);
+        const priceVarVal = Number.isFinite(priceVarFromState) ? priceVarFromState : (Number.isFinite(tmplPriceVar) ? tmplPriceVar : 0);
+        nextSc.cost[configuredCostKey] = { multiply: priceVarVal };
+        nextSc.id = idFromTemplate;
+        entry.scenarios[targetIndex] = nextSc;
+        onApply(JSON.stringify(runs, null, 2));
+        // Update local pricing state so UI reflects chosen values immediately
+        setPricing((prev) => {
+          const current = prev[variantId] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+          const nextIncs = current.increments.slice();
+          const nextPriceVar = current.priceVar.slice();
+          while (nextIncs.length <= targetIndex) nextIncs.push(0);
+          while (nextPriceVar.length <= targetIndex) nextPriceVar.push(0);
+          nextIncs[targetIndex] = incVal;
+          nextPriceVar[targetIndex] = priceVarVal;
+          return { ...prev, [variantId]: { ...current, increments: nextIncs, priceVar: nextPriceVar } };
+        });
+      } else {
+        // Immediately remove scenario from JSON by id
+        let parsed: any = [];
+        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+        const runs: any[] = Array.isArray(parsed) ? parsed : [];
+        const v = variantDefs.find((d) => d.id === variantId);
+        if (!v) return;
+        const variantPath = v.id;
+        const entry = runs.find((r) => r && r.elements_variant === variantPath);
+        if (entry && Array.isArray(entry.scenarios)) {
+          const idFromTemplate = (templateScenarioIds[variantId] && templateScenarioIds[variantId][idx] != null)
+            ? Number(templateScenarioIds[variantId][idx])
+            : (idx + 1);
+          let targetIndex = entry.scenarios.findIndex((sc: any) => sc && typeof sc === "object" && Number(sc.id) === Number(idFromTemplate));
+          if (targetIndex === -1 && idx < entry.scenarios.length) targetIndex = idx;
+          if (targetIndex !== -1) {
+            entry.scenarios.splice(targetIndex, 1);
+            onApply(JSON.stringify(runs, null, 2));
+          }
+        }
+      }
+    } catch {}
+    setScenarioEnabled((prev) => {
+      const current = prev[variantId] ? prev[variantId].slice() : [];
+      while (current.length <= idx) current.push(false);
+      current[idx] = enabled;
+      return { ...prev, [variantId]: current };
+    });
+  }
+
+  // (removed immediate JSON writes; apply on OK)
+
+  return (
+    <Drawer
+      title="Edit DPE JSON"
+      placement="right"
+      open={open}
+      onClose={handleDrawerClose}
+      width={width}
+      mask
+      maskClosable
+      extra={
+        <Space>
+          <Button type="primary" onClick={applyEditorChanges}>OK</Button>
+        </Space>
+      }
+    >
+      <Space direction="vertical" size={16} style={{ width: "100%" }}>
+        {variantDefs.map((v) => {
+          const st = editorState[v.id] || { enabled: false, index: 0, text: "{\n}\n" };
+          return (
+            <Card key={v.id} size="small" styles={{ body: { padding: 12 } }} style={{ background: st.enabled ? "#ffffff" : "#f5f5f5" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                <div style={{ fontWeight: 600 }}>{v.label}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div>enabled</div>
+                  <Switch
+                    checked={st.enabled}
+                    onChange={(checked) => {
+                      setEditorState((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || { enabled: false, index: 0, text: "{\n}\n" }), enabled: checked } }));
+                      try {
+                        let parsed: any = [];
+                        try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                        if (Array.isArray(parsed)) {
+                          const runs: any[] = parsed;
+                          const variantPath = v.id;
+                          const idxInRuns = runs.findIndex((r) => r && r.elements_variant === variantPath);
+                          if (!checked) {
+                            if (idxInRuns !== -1) {
+                              runs.splice(idxInRuns, 1);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                            setScenarioEnabled((prev) => ({ ...prev, [v.id]: [] }));
+                            setScopeStrategy((prev) => ({ ...prev, [v.id]: "all" }));
+                          } else {
+                            if (idxInRuns === -1) {
+                              const entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                              runs.push(entry);
+                              onApply(JSON.stringify(runs, null, 2));
+                            }
+                          }
+                        }
+                      } catch {}
+                    }}
+                  />
+                </div>
+              </div>
+              <div style={{ height: 8 }} />
+              <div style={{ color: "#6b7280", fontSize: 12 }}>
+                dpe.logement.enveloppe.{v.collection}.{v.itemKey}
+              </div>
+              <div style={{ height: 8 }} />
+              {/* index selector removed */}
+              {(availableOptions[v.id] && Array.isArray(availableOptions[v.id]) && (availableOptions[v.id] as any[]).length > 0) ? (
+                <div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                    <div style={{ fontWeight: 500 }}>Scope</div>
+                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                      "right click" for details
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    {(availableOptions[v.id] || []).map((opt, idx) => {
+                      const detailsData = { variant: v.id, collection: v.collection, itemKey: v.itemKey, index: idx, key: opt.key, selected: opt.selected, payload: opt.payload };
+                      return (
+                        <label
+                          key={opt.key}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            setDetailsModal({ open: true, title: `${v.label} · ${opt.description}`, data: detailsData });
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            padding: "4px 6px",
+                            borderRadius: 6,
+                            background: highlighted[v.id]?.[opt.key] ? "#fff7ed" : "transparent",
+                            transition: "background-color 600ms ease",
+                          }}
+                        >
+                          <Checkbox
+                            checked={opt.selected}
+                            onChange={(e) => {
+                            const checked = e.target.checked;
+                            // Update JSON immediately (runs array with elements_scope) and highlight
+                            try {
+                              let parsed: any = [];
+                              try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                              const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                              const collectionName = v.collection;
+                              const itemKey = v.itemKey;
+                              const variantPath = v.id;
+                              let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                              if (!entry) {
+                                entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                                runs.push(entry);
+                              }
+                              const optionIdx = idx; // 0-based index in available options order
+                              const scopes: number[] = Array.isArray(entry.elements_scope) ? [...entry.elements_scope] : [];
+                              const has = scopes.includes(optionIdx);
+                              if (checked && !has) scopes.push(optionIdx);
+                              if (!checked && has) {
+                                const pos = scopes.indexOf(optionIdx);
+                                if (pos !== -1) scopes.splice(pos, 1);
+                              }
+                              entry.elements_scope = scopes;
+
+                              onApply(JSON.stringify(runs, null, 2));
+                              message.success(checked ? "Added option to JSON" : "Removed option from JSON");
+
+                              // Ask parent to highlight the corresponding indices in scope
+                              try {
+                                const indices = scopes.slice().sort((a, b) => a - b);
+                                if (indices.length > 0) onHighlightJsonPath?.({ collection: collectionName, itemKey, indices });
+                              } catch {}
+
+                              const refKey = String(opt.key);
+                              setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: true } }));
+                              window.setTimeout(() => {
+                                setHighlighted((prev) => ({ ...prev, [v.id]: { ...(prev[v.id] || {}), [refKey]: false } }));
+                              }, 1000);
+                              // noop
+                            } catch (err) {
+                              // eslint-disable-next-line no-console
+                              console.error("Failed to update JSON from option toggle", err);
+                              message.error("Failed to update JSON");
+                            }
+                            }}
+                          />
+                          <span style={{ fontSize: 12, color: "#374151" }}>{opt.description}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ height: 8 }} />
+              <div style={{ display: "flex", alignItems: "center", gap: 8, justifyContent: "flex-end" }}>
+                <div style={{ fontWeight: 500 }}>explode</div>
+                <Switch
+                  checked={scopeStrategy[v.id] === "explode"}
+                  onChange={(checked) => {
+                    try {
+                      let parsed: any = [];
+                      try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                      const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                      const collectionName = v.collection;
+                      const itemKey = v.itemKey;
+                      const variantPath = v.id;
+                      let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                      if (!entry) {
+                        entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                        runs.push(entry);
+                      }
+                      entry.scope_strategy = checked ? "explode" : "all";
+                      onApply(JSON.stringify(runs, null, 2));
+                      setScopeStrategy((prev) => ({ ...prev, [v.id]: entry.scope_strategy }));
+                    } catch {
+                      message.error("Failed to update scope strategy");
+                    }
+                  }}
+                />
+              </div>
+              <div style={{ height: 8 }} />
+              <div>
+                <div style={{ fontWeight: 500, marginBottom: 6 }}>Scenarios</div>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: `80px repeat(3, minmax(72px, 1fr))`,
+                    gap: 4,
+                    alignItems: "center",
+                  }}
+                >
+                  {/* Header row: columns as Increment | Price var | Price fix */}
+                  <div />
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Increment</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price var</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+                  <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                    <span>Price fix</span>
+                    <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                  </div>
+
+                  {(() => {
+                    const presentIds = getPresentScenarioIds(v.id);
+                    const presentIdsSet = new Set<number>(presentIds);
+                    const rowIds: number[] = (templateScenarioIds[v.id] || []).slice();
+                    return rowIds.map((scenarioId, idx) => {
+                      const isPresentInJson = presentIdsSet.has(Number(scenarioId));
+                      const isEnabled = Boolean(scenarioEnabled[v.id]?.[idx]);
+                      const presentIndex = presentIds.indexOf(Number(scenarioId));
+                      const tmplIdx = idx; // template index aligns with templateDerived
+                      const tmplInc = templateDerived[v.id]?.increments?.[tmplIdx];
+                      const tmplPriceVar = templateDerived[v.id]?.priceVar?.[tmplIdx];
+                      const incVal = presentIndex !== -1
+                        ? (pricing[v.id]?.increments?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplInc) ? Number(tmplInc) : 0);
+                      const priceVarVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceVar?.[presentIndex] ?? 0)
+                        : (Number.isFinite(tmplPriceVar) ? Number(tmplPriceVar) : 0);
+                      const priceFixVal = presentIndex !== -1
+                        ? (pricing[v.id]?.priceFix?.[presentIndex] ?? 0)
+                        : 0;
+                      return (
+                        <React.Fragment key={`row-${idx}`}>
+                          <label style={{ display: "flex", alignItems: "center", gap: 6, color: isPresentInJson ? "#6b7280" : "#9ca3af", fontSize: 12 }}>
+                            <Checkbox
+                              checked={Boolean(scenarioEnabled[v.id]?.[idx])}
+                              onChange={(e) => toggleScenarioPresence(v.id, idx, e.target.checked)}
+                            />
+                            <span>#{scenarioId}</span>
+                          </label>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={incVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextIncs = current.increments.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextIncs.length <= idxToSet) nextIncs.push(0);
+                                  nextIncs[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, increments: nextIncs } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceVarVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceVar.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceVar: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 6, opacity: isPresentInJson ? 1 : 0.6 }}>
+                            <InputNumber
+                              size="small"
+                              controls={false}
+                              min={0}
+                              value={priceFixVal}
+                              disabled={!isEnabled}
+                              onChange={(next) => {
+                                const nextVal = Number(next ?? 0);
+                                setPricing((prev) => {
+                                  const current = prev[v.id] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+                                  const nextPrices = current.priceFix.slice();
+                                  const idxToSet = presentIndex !== -1 ? presentIndex : idx;
+                                  while (nextPrices.length <= idxToSet) nextPrices.push(0);
+                                  nextPrices[idxToSet] = nextVal;
+                                  return { ...prev, [v.id]: { ...current, priceFix: nextPrices } };
+                                });
+                              }}
+                              style={{ width: "100%" }}
+                            />
+                          </div>
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </Space>
+      <Modal
+        title="Column settings"
+        open={colSettings.open}
+        onCancel={() => setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" })}
+        onOk={() => {
+          try {
+            if (!colSettings.variant || !colSettings.field) return;
+            const variant = colSettings.variant;
+            const field = colSettings.field;
+            if (field === "increments") {
+              const text = (colSettings.tempForcedInputs || "").trim();
+              if (text) {
+                try {
+                  const parsed = JSON.parse(text);
+                  const pretty = JSON.stringify(parsed, null, 2) + "\n";
+                  setForcedInputs((prev) => ({ ...prev, [variant]: pretty }));
+                } catch {
+                  message.error("Invalid JSON in Forced inputs");
+                  return;
+                }
+              } else {
+                setForcedInputs((prev) => ({ ...prev, [variant]: "" }));
+              }
+            }
+            setPricing((prev) => {
+              const current = prev[variant] || { increments: [], priceVar: [], priceFix: [], incrementUnit: "cm", priceUnit: "EUR/m2" };
+              if (field === "increments") {
+                return { ...prev, [variant]: { ...current, incrementUnit: colSettings.tempUnit || current.incrementUnit } };
+              }
+              return { ...prev, [variant]: { ...current, priceUnit: colSettings.tempUnit || current.priceUnit } };
+            });
+            setMappingKeys((prev) => {
+              const current = prev[variant] || {};
+              if (field === "increments") return { ...prev, [variant]: { ...current, inputKey: colSettings.tempKey || current.inputKey } };
+              return { ...prev, [variant]: { ...current, costKey: colSettings.tempKey || current.costKey } };
+            });
+
+            // Persist parameters into JSON for the variant when editing increments
+            if (field === "increments") {
+              try {
+                let parsed: any = [];
+                try { parsed = rootJsonText.trim() ? JSON.parse(rootJsonText) : []; } catch { parsed = []; }
+                const runs: any[] = Array.isArray(parsed) ? parsed : [];
+                const v = variantDefs.find((d) => d.id === variant);
+                if (!v) return;
+                const variantPath = v.id;
+                let entry = runs.find((r) => r && r.elements_variant === variantPath);
+                if (!entry) {
+                  entry = { elements_variant: variantPath, elements_scope: [], scope_strategy: "all", scenarios: [] };
+                  runs.push(entry);
+                }
+                if (!entry.parameters || typeof entry.parameters !== "object") entry.parameters = {};
+                if (colSettings.tempUnit) entry.parameters.unit = colSettings.tempUnit;
+                const text = (colSettings.tempForcedInputs || "").trim();
+                if (text) {
+                  try {
+                    const forcedObj = JSON.parse(text);
+                    if (forcedObj && typeof forcedObj === "object") {
+                      entry.parameters.input_forced = forcedObj;
+                    }
+                  } catch {}
+                }
+                onApply(JSON.stringify(runs, null, 2));
+              } catch {}
+            }
+          } finally {
+            setColSettings({ open: false, variant: null, field: null, tempUnit: "", tempKey: "", tempForcedInputs: "" });
+          }
+        }}
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>
+              {colSettings.field === "increments" ? "Scenario input key (index mapping)" : "Scenario cost key (index mapping)"}
+            </div>
+            <Input
+              value={colSettings.tempKey}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
+              placeholder={colSettings.variant ? (
+                colSettings.field === "increments"
+                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+              ) : ""}
+            />
+          </div>
+          <div>
+            <div style={{ marginBottom: 6, color: "#4b5563" }}>Unit</div>
+            <Input
+              value={colSettings.tempUnit}
+              onChange={(e) => setColSettings((prev) => ({ ...prev, tempUnit: e.target.value }))}
+              placeholder="e.g. cm or EUR/m2"
+            />
+          </div>
+          {colSettings.field === "increments" ? (
+            <div>
+              <div style={{ marginBottom: 6, color: "#4b5563" }}>Forced inputs (JSON)</div>
+              <Input.TextArea
+                value={colSettings.tempForcedInputs}
+                onChange={(e) => setColSettings((prev) => ({ ...prev, tempForcedInputs: e.target.value }))}
+                rows={3}
+                placeholder="{\n}\n"
+                style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, monospace" }}
+              />
+            </div>
+          ) : null}
+        </Space>
+      </Modal>
+      <Modal
+        title={detailsModal.title || "Details"}
+        open={detailsModal.open}
+        onCancel={() => setDetailsModal({ open: false, title: "", data: null })}
+        footer={[
+          <Button key="close" onClick={() => setDetailsModal({ open: false, title: "", data: null })}>Close</Button>,
+        ]}
+        width={720}
+      >
+        <div style={{ maxHeight: 480, overflow: "auto" }}>
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>
+{detailsModal.data ? JSON.stringify(detailsModal.data, null, 2) : ""}
+          </pre>
+        </div>
+      </Modal>
+    </Drawer>
+  );
+};
+
+
+
+```
+
+- Clicking outside the right drawer now behaves like pressing close: I enabled the Drawer’s mask and maskClosable so outside clicks trigger `onClose`.
+- The existing `handleDrawerClose` already asks to discard changes if JSON has been modified, so you’ll get the same confirmation modal on outside clicks.
+
+Try: open the editor, make a change, then click outside; you should see the discard prompt.
+

--- a/packages/dpe-editor/src/ui/DpeDrawerEditor.tsx
+++ b/packages/dpe-editor/src/ui/DpeDrawerEditor.tsx
@@ -278,8 +278,8 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
       const entry = runsArr.find((r) => r && r.elements_variant === variantId);
       const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
       if (!scenarios.length) return empty;
-      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
-      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKeyFromRuns(runsArr, variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKeyFromRuns(runsArr, variantId) || "donnee_entree.surface_paroi_opaque";
       const increments: number[] = scenarios.map((sc) => {
         const val = sc?.input?.[inputKey]?.set;
         const num = typeof val === "number" ? val : Number(val);
@@ -376,8 +376,8 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
             (scenarioEnabled[v.id] || []).length,
             (templateScenarioIds[v.id] || []).length
           );
-          const configuredInputKey = mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
-          const configuredCostKey = mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
+          const configuredInputKey = mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "donnee_entree.epaisseur_isolation";
+          const configuredCostKey = mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "donnee_entree.surface_paroi_opaque";
 
           for (let idx = 0; idx < rowCount; idx += 1) {
             const enabled = Boolean(scenarioEnabled[v.id]?.[idx]);
@@ -512,6 +512,21 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
     return undefined;
   }
 
+  function getTemplateScenarioInputKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
   function getFirstScenarioCostKey(variantId: VariantId): string | undefined {
     try {
       let parsed: any = [];
@@ -530,6 +545,52 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
     return undefined;
   }
 
+  function getTemplateScenarioCostKey(variantId: VariantId): string | undefined {
+    try {
+      const entry = (Array.isArray(templateRuns) ? templateRuns : []).find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  // Helpers to derive keys directly from a provided runs[] array (e.g., template)
+  function getFirstScenarioInputKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const inputObj = sc?.input || sc?.inputs || undefined;
+        if (inputObj && typeof inputObj === "object") {
+          const keys = Object.keys(inputObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
+  function getFirstScenarioCostKeyFromRuns(runsArr: any[], variantId: VariantId): string | undefined {
+    try {
+      const entry = runsArr.find((r) => r && r.elements_variant === variantId);
+      const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
+      for (const sc of scenarios) {
+        const costObj = sc?.cost || undefined;
+        if (costObj && typeof costObj === "object") {
+          const keys = Object.keys(costObj);
+          if (keys.length > 0) return keys[0];
+        }
+      }
+    } catch {}
+    return undefined;
+  }
+
   function deriveVariantPricing(variantId: VariantId): { increments: number[]; priceVar: number[] } {
     const empty = { increments: [] as number[], priceVar: [] as number[] };
     try {
@@ -539,8 +600,8 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
       const entry = runs.find((r) => r && r.elements_variant === variantId);
       const scenarios: any[] = Array.isArray(entry?.scenarios) ? entry.scenarios : [];
       if (!scenarios.length) return empty;
-      const inputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
-      const costKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+      const inputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+      const costKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
       const increments: number[] = scenarios.map((sc) => {
         const val = sc?.input?.[inputKey]?.set;
         const num = typeof val === "number" ? val : Number(val);
@@ -659,8 +720,8 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
         if (targetIndex === -1) targetIndex = entry.scenarios.length;
         while (entry.scenarios.length <= targetIndex) entry.scenarios.push(null);
         const current = entry.scenarios[targetIndex];
-        const configuredInputKey = mappingKeys[variantId]?.inputKey || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
-        const configuredCostKey = mappingKeys[variantId]?.costKey || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
+        const configuredInputKey = mappingKeys[variantId]?.inputKey || getTemplateScenarioInputKey(variantId) || getFirstScenarioInputKey(variantId) || "donnee_entree.epaisseur_isolation";
+        const configuredCostKey = mappingKeys[variantId]?.costKey || getTemplateScenarioCostKey(variantId) || getFirstScenarioCostKey(variantId) || "donnee_entree.surface_paroi_opaque";
         const nextSc: any = current && typeof current === "object" ? current : { id: idFromTemplate, input: {}, cost: {} };
         if (!nextSc.input || typeof nextSc.input !== "object") nextSc.input = {};
         if (!nextSc.cost || typeof nextSc.cost !== "object") nextSc.cost = {};
@@ -915,17 +976,17 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
                   <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
                     <span>Increment</span>
                     <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.incrementUnit || "cm"})</span>
-                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "increments", tempUnit: pricing[v.id]?.incrementUnit || "cm", tempKey: mappingKeys[v.id]?.inputKey || getTemplateScenarioInputKey(v.id) || getFirstScenarioInputKey(v.id) || "", tempForcedInputs: forcedInputs[v.id] || "{\n}\n" })} />
                   </div>
                   <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
                     <span>Price var</span>
                     <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
-                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceVar", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
                   </div>
                   <div style={{ color: "#4b5563", fontSize: 12, display: "flex", alignItems: "center", gap: 6 }}>
                     <span>Price fix</span>
                     <span style={{ color: "#9ca3af" }}>({pricing[v.id]?.priceUnit || "EUR/m2"})</span>
-                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
+                    <Button size="small" type="text" icon={<span aria-hidden="true">⚙️</span>} onClick={() => setColSettings({ open: true, variant: v.id, field: "priceFix", tempUnit: pricing[v.id]?.priceUnit || "EUR/m2", tempKey: mappingKeys[v.id]?.costKey || getTemplateScenarioCostKey(v.id) || getFirstScenarioCostKey(v.id) || "", tempForcedInputs: "" })} />
                   </div>
 
                   {(() => {
@@ -1110,8 +1171,8 @@ export const DpeDrawerEditor: React.FC<DpeDrawerEditorProps> = ({ open, onClose,
               onChange={(e) => setColSettings((prev) => ({ ...prev, tempKey: e.target.value }))}
               placeholder={colSettings.variant ? (
                 colSettings.field === "increments"
-                  ? (getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
-                  : (getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
+                  ? (getTemplateScenarioInputKey(colSettings.variant) || getFirstScenarioInputKey(colSettings.variant) || "donnee_entree.epaisseur_isolation")
+                  : (getTemplateScenarioCostKey(colSettings.variant) || getFirstScenarioCostKey(colSettings.variant) || "donnee_entree.surface_paroi_opaque")
               ) : ""}
             />
           </div>

--- a/packages/load-scenario/README.md
+++ b/packages/load-scenario/README.md
@@ -1,0 +1,15 @@
+@acme/load-scenario
+
+A simple modal to load saved simulation scenarios from the backoffice API.
+
+Props:
+- open: boolean
+- onCancel: () => void
+- onSelect: (payload: unknown) => void
+- baseUrl?: string (defaults to https://api-dev.etiquettedpe.fr)
+- initialRefAdeme?: string
+- getAccessToken: () => Promise<string | null>
+
+It performs GET /backoffice/simulation_scenario_saved?ref_ademe=... with the Cognito Bearer token when available and displays the results in a small table with a "load" action per row.
+
+

--- a/packages/load-scenario/package.json
+++ b/packages/load-scenario/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@acme/load-scenario",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check": "tsc -b && eslint .",
+    "test": "echo 'no tests'"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "antd": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "antd": "^5.27.4"
+  }
+}
+
+

--- a/packages/load-scenario/src/index.ts
+++ b/packages/load-scenario/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./loadScenarioModal";
+
+

--- a/packages/load-scenario/src/loadScenarioModal.tsx
+++ b/packages/load-scenario/src/loadScenarioModal.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Modal, Input, Typography, Space, Select, Button, Table, Tag } from "antd";
+
+export type LoadScenarioModalProps = {
+  open: boolean;
+  onCancel: () => void;
+  onSelect: (payload: unknown) => void;
+  /**
+   * Used to build the API URL. Defaults to https://api-dev.etiquettedpe.fr
+   */
+  baseUrl?: string;
+  /** If provided, prefill ref_ademe */
+  initialRefAdeme?: string;
+  /** Provide a function that returns a Cognito access token string */
+  getAccessToken: () => Promise<string | null>;
+};
+
+type SavedScenarioItem = {
+  id?: string | number;
+  created_at?: string;
+  label?: string;
+  ref_ademe?: string;
+  // Any other fields we might receive
+  [key: string]: unknown;
+};
+
+export const LoadScenarioModal: React.FC<LoadScenarioModalProps> = ({ open, onCancel, onSelect, baseUrl = "https://api-dev.etiquettedpe.fr", initialRefAdeme, getAccessToken }) => {
+  const [refAdeme, setRefAdeme] = useState<string>(initialRefAdeme || "");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<SavedScenarioItem[] | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setItems(null);
+    setError(null);
+    // Preset ref_ademe with current one each time the modal opens
+    setRefAdeme(initialRefAdeme || "");
+  }, [open, initialRefAdeme]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (refAdeme && refAdeme.trim()) {
+      // auto-fetch when opening with a prefilled ref_ademe
+      void fetchSaved();
+    }
+  }, [open, refAdeme]);
+
+  async function fetchSaved() {
+    try {
+      setLoading(true);
+      setError(null);
+      const token = await getAccessToken();
+      const url = new URL("/backoffice/simulation_scenario_saved", baseUrl);
+      if (refAdeme) url.searchParams.set("ref_ademe", refAdeme);
+      const res = await fetch(url.toString(), {
+        method: "GET",
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Accept: "application/json, text/plain, */*",
+        },
+      });
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status} ${txt}`);
+      }
+      const data = (await res.json().catch(() => null)) as unknown;
+      const raw: unknown[] = Array.isArray((data as any)?.items)
+        ? ((data as any).items as unknown[])
+        : (Array.isArray(data) ? (data as unknown[]) : []);
+      const normalized: SavedScenarioItem[] = raw.map((it) => {
+        if (typeof it === "string") {
+          const colon = it.indexOf(":");
+          const ref = colon !== -1 ? it.slice(0, colon) : undefined;
+          const label = colon !== -1 ? it.slice(colon + 1) : it;
+          return { id: it, ref_ademe: ref, label } as SavedScenarioItem;
+        }
+        if (it && typeof it === "object") return it as SavedScenarioItem;
+        return { id: String(it), label: String(it) } as SavedScenarioItem;
+      });
+      setItems(normalized);
+    } catch (e: any) {
+      setError(e?.message || "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const columns = useMemo(
+    () => [
+      { title: "Label", dataIndex: "label", key: "label", render: (v: any) => v || "(no label)" },
+      { title: "Ref", dataIndex: "ref_ademe", key: "ref_ademe" },
+      { title: "Created", dataIndex: "created_at", key: "created_at" },
+      {
+        title: "",
+        key: "action",
+        render: (_: any, record: SavedScenarioItem) => (
+          <Button type="link" onClick={() => onSelect(record)}>load</Button>
+        ),
+      },
+    ],
+    [onSelect]
+  );
+
+  return (
+    <Modal
+      title="Load scenario"
+      open={open}
+      onCancel={onCancel}
+      footer={null}
+      destroyOnHidden
+   >
+      <Space direction="vertical" size={12} style={{ width: "100%" }}>
+        <div>
+          <div style={{ marginBottom: 6, color: "#4b5563" }}>ref_ademe</div>
+          <Input value={refAdeme} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setRefAdeme(e.target.value)} placeholder="e.g. 2394E0980765L" />
+        </div>
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button type="primary" onClick={fetchSaved} loading={loading}>Fetch</Button>
+        </div>
+        {error && (
+          <div style={{ color: "#b91c1c" }}>{error}</div>
+        )}
+        {Array.isArray(items) && (
+          <Table
+            dataSource={items}
+            columns={columns as any}
+            rowKey={(r: SavedScenarioItem) => String(r.id ?? `${r.ref_ademe}-${r.created_at}`)}
+            pagination={false}
+            size="small"
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+};
+
+

--- a/packages/load-scenario/tsconfig.json
+++ b/packages/load-scenario/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}
+
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@acme/dpe-editor':
         specifier: workspace:*
         version: link:../../packages/dpe-editor
+      '@acme/load-scenario':
+        specifier: workspace:*
+        version: link:../../packages/load-scenario
       '@acme/simulation-scenarios':
         specifier: workspace:*
         version: link:../../packages/simulation-scenarios
@@ -301,6 +304,22 @@ importers:
         version: 1.6.1(@types/node@20.19.17)(jsdom@24.1.3)(sass-embedded@1.93.0)(sass@1.93.0)
 
   packages/dpe-editor:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      antd:
+        specifier: ^5.27.4
+        version: 5.27.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+
+  packages/load-scenario:
     dependencies:
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
This commit introduces the @acme/load-scenario package, which provides a modal for loading saved simulation scenarios from the backoffice API. The modal allows users to input a reference ID (ref_ademe) and fetch saved scenarios, displaying them in a table with options to load each scenario. The implementation includes necessary dependencies and configuration files, ensuring seamless integration with the existing application. Lint checks passed.